### PR TITLE
FreeBSD: rewrited sysload plugin 

### DIFF
--- a/plugins/sysload/__init__.py
+++ b/plugins/sysload/__init__.py
@@ -1,11 +1,6 @@
 MODULES = ['api', 'widget', 'ss_linux', 'ss_bsd']
 
-DEPS =  [
-    (['freebsd'],
-     [
-        ('app', 'sysutils/freecolor', 'freecolor'),
-     ])
-]
+DEPS =  []
 
 NAME = 'System Load'
 PLATFORMS = ['any']

--- a/plugins/sysload/ss_bsd.py
+++ b/plugins/sysload/ss_bsd.py
@@ -6,20 +6,18 @@ from ajenti.com import *
 class BSDSysStat(Plugin):
     implements(apis.sysstat.ISysStat)
     platform = ['freebsd']
-    
+
     def get_load(self):
         return shell('sysctl vm.loadavg').split()[2:5]
-        
+
     def get_ram(self):
-        s = shell('freecolor -om | grep Mem').split()[1:]
+        s = shell("top -b | grep Mem | sed 's/[^0-9]/ /g' | awk '{print $1+$2+$3+$4+$5+$6, $1+$2+$3, $4+$5+$6}'").split()
         t = int(s[0])
         u = int(s[1])
-        b = int(s[4])
-        c = int(s[5])
-        u -= c + b;
+        f = int(s[2])
         return (u, t)
 
     def get_swap(self):
-        s = shell('freecolor -om | grep Swap').split()[1:]
+        s = shell('top -b | grep Swap | sed "s/[^0-9]/ /g"').split()
         return (int(s[1]), int(s[0]))
 


### PR DESCRIPTION
Rewrited the sysload plugin for BSD to not use the freecolor but parse an output from the bsd top utility
