### PR TITLE
Allow configuration parameters with underscore prefix.

### DIFF
--- a/ajenti/api/helpers.py
+++ b/ajenti/api/helpers.py
@@ -233,7 +233,7 @@ class ModuleConfig(Plugin):
     def overlay_config(self):
         section = 'cfg_' + self.target.__name__
         for k in self.__class__.__dict__:
-            if not k in ['platform', 'plugin', 'labels'] and not k.startswith('_'):
+            if not k in ['platform', 'plugin', 'labels']:
                 if self.app.config.has_option(section, k):
                     setattr(self, k, eval(self.app.config.get(section, k)))
 

--- a/plugins/notepad/config.py
+++ b/plugins/notepad/config.py
@@ -5,10 +5,10 @@ from main import *
 class GeneralConfig(ModuleConfig):
     target = NotepadPlugin
     platform = ['any']
-    
+
     labels = {
         'dir': 'Initial directory'
     }
-    
+
     dir = '/etc'
-   
+    _chroot = None

--- a/plugins/notepad/main.py
+++ b/plugins/notepad/main.py
@@ -26,7 +26,11 @@ class NotepadPlugin(CategoryPlugin):
 
     def add_tab(self):
         self._tab = len(self._roots)
-        self._roots.append(self.app.get_config(self).dir)
+        chroot = self.app.get_config(self)._chroot
+        dir = self.app.get_config(self).dir
+        if chroot is not None and not dir.startswith(chroot):
+            dir = chroot
+        self._roots.append(dir)
         self._files.append(None)
         self._data.append(None)
 
@@ -36,7 +40,12 @@ class NotepadPlugin(CategoryPlugin):
         mui.append('main', tabs)
 
         idx = 0
+        chroot = self.app.get_config(self)._chroot
+
         for root in self._roots:
+            if chroot is not None and not root.startswith(chroot):
+                root = chroot
+
             file = self._files[idx]
             data = self._data[idx]
 
@@ -58,7 +67,7 @@ class NotepadPlugin(CategoryPlugin):
                     )
                   )
 
-            if root != '/':
+            if root != '/' and (chroot is None or root != chroot):
                 files.append(
                     UI.ListItem(
                         UI.HContainer(


### PR DESCRIPTION
It will be nice to be able to set options in config file, which cannot be modified by user from panel.  
I'm trying to make backward-compatible version of ajenti with ability to restrict access to some features (for example installing plugins, editing files outside specified directories) and need this kind of parameters in some standard plugins.  
If you know any simple way preventing patching the code to achieve this functionality in plugins, I'll be happy to know :)
