### PR TITLE
fix network plugin on arch

### DIFF
--- a/plugins/network/api.py
+++ b/plugins/network/api.py
@@ -74,7 +74,7 @@ class NetworkInterface(object):
         self.bits = []
         self.params = {'address': '0.0.0.0'}
         self.type = ''
-	self.editable = True
+        self.editable = True
         
     def __getitem__(self, idx):
         if self.params.has_key(idx):

--- a/plugins/network/api.py
+++ b/plugins/network/api.py
@@ -74,6 +74,7 @@ class NetworkInterface(object):
         self.bits = []
         self.params = {'address': '0.0.0.0'}
         self.type = ''
+	self.editable = True
         
     def __getitem__(self, idx):
         if self.params.has_key(idx):

--- a/plugins/network/main.py
+++ b/plugins/network/main.py
@@ -33,9 +33,9 @@ class NetworkPlugin(CategoryPlugin):
                             UI.HContainer(
                                 UI.TipIcon(icon='/dl/core/ui/stock/info.png',
                                     text='Info', id='info/' + i.name),
-				UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
-				    text='Edit', id='editiface/' + i.name),
-				UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
+                                    UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
+                                    text='Edit', id='editiface/' + i.name),
+                                    UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
                                     text=('Down' if i.up else 'Up'), 
                                     id=('if' + ('down' if i.up else 'up') + '/' + i.name), 
                                     warning='Bring %s interface %s' % (('Down' if i.up else 'Up'), i.name)

--- a/plugins/network/main.py
+++ b/plugins/network/main.py
@@ -33,9 +33,9 @@ class NetworkPlugin(CategoryPlugin):
                             UI.HContainer(
                                 UI.TipIcon(icon='/dl/core/ui/stock/info.png',
                                     text='Info', id='info/' + i.name),
-                                    UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
+                                UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
                                     text='Edit', id='editiface/' + i.name),
-                                    UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
+                                UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
                                     text=('Down' if i.up else 'Up'), 
                                     id=('if' + ('down' if i.up else 'up') + '/' + i.name), 
                                     warning='Bring %s interface %s' % (('Down' if i.up else 'Up'), i.name)

--- a/plugins/network/main.py
+++ b/plugins/network/main.py
@@ -33,9 +33,9 @@ class NetworkPlugin(CategoryPlugin):
                             UI.HContainer(
                                 UI.TipIcon(icon='/dl/core/ui/stock/info.png',
                                     text='Info', id='info/' + i.name),
-                                UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
-                                    text='Edit', id='editiface/' + i.name),
-                                UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
+				UI.TipIcon(icon='/dl/core/ui/stock/edit.png',
+				    text='Edit', id='editiface/' + i.name),
+				UI.TipIcon(icon='/dl/core/ui/stock/service-%s.png'%('run' if not i.up else 'stop'), 
                                     text=('Down' if i.up else 'Up'), 
                                     id=('if' + ('down' if i.up else 'up') + '/' + i.name), 
                                     warning='Bring %s interface %s' % (('Down' if i.up else 'Up'), i.name)

--- a/plugins/network/nc_arch.py
+++ b/plugins/network/nc_arch.py
@@ -3,11 +3,11 @@ from ajenti.utils import *
 from ajenti import apis
 
 from api import *
-from nctp_linux import *
+from nctp_ip import *
 
 rc_net_keys = ('address', 'netmask', 'broadcast', 'gateway')
 
-class ArchNetworkConfig(LinuxIfconfig):
+class ArchNetworkConfig(LinuxIp):
     implements(INetworkConfig)
     platform = ['Arch']
     
@@ -30,16 +30,32 @@ class ArchNetworkConfig(LinuxIfconfig):
         iface.auto = True
         self.interfaces[name] = iface
         
-        for key in rc_net_keys:
-            value = self.rcconf.get_param(key)
-            if key == 'address':
-                iface.addressing = 'dhcp' if value == '' else 'static'
-            iface.params[key] = value
+	if self.rcconf.has_param('INTERFACES'):
+          for key in rc_net_keys:
+              value = self.rcconf.get_param(key)
+              if key == 'address':
+                  iface.addressing = 'dhcp' if value == '' else 'static'
+              iface.params[key] = value
         
-        iface.devclass = self.detect_dev_class(iface)
-        iface.up = shell_status('ifconfig ' + iface.name + '|grep UP') == 0
-        iface.get_bits(self.app, self.detect_iface_bits(iface))
-    
+          iface.devclass = self.detect_dev_class(iface)
+          iface.up = shell_status('ifconfig ' + iface.name + '|grep UP') == 0
+          iface.get_bits(self.app, self.detect_iface_bits(iface))
+	else:
+	  s = shell('ip -o link list')
+
+	  for line in s.split('\n'):
+	    line = line.strip()
+	    if line != '':
+ 	      name = line.split(':')[1].strip()
+              iface = NetworkInterface()
+	      iface.name = name
+	      self.interfaces[name] = iface
+	      iface.devclass = self.detect_dev_class(iface)
+	      iface.up = (line.find('state UP') != -1)
+	      iface.get_bits(self.app, self.detect_iface_bits(iface))
+	      iface.editable = False
+   
+
     def save(self):
         for iface in self.interfaces.values():
             for key in rc_net_keys:

--- a/plugins/network/nc_arch.py
+++ b/plugins/network/nc_arch.py
@@ -30,30 +30,29 @@ class ArchNetworkConfig(LinuxIp):
         iface.auto = True
         self.interfaces[name] = iface
         
-	if self.rcconf.has_param('INTERFACES'):
-          for key in rc_net_keys:
-              value = self.rcconf.get_param(key)
-              if key == 'address':
-                  iface.addressing = 'dhcp' if value == '' else 'static'
-              iface.params[key] = value
-        
-          iface.devclass = self.detect_dev_class(iface)
-          iface.up = shell_status('ifconfig ' + iface.name + '|grep UP') == 0
-          iface.get_bits(self.app, self.detect_iface_bits(iface))
-	else:
-	  s = shell('ip -o link list')
+        if self.rcconf.has_param('INTERFACES'):
+            for key in rc_net_keys:
+                value = self.rcconf.get_param(key)
+                if key == 'address':
+                    iface.addressing = 'dhcp' if value == '' else 'static'
+                iface.params[key] = value
 
-	  for line in s.split('\n'):
-	    line = line.strip()
-	    if line != '':
- 	      name = line.split(':')[1].strip()
-              iface = NetworkInterface()
-	      iface.name = name
-	      self.interfaces[name] = iface
-	      iface.devclass = self.detect_dev_class(iface)
-	      iface.up = (line.find('state UP') != -1)
-	      iface.get_bits(self.app, self.detect_iface_bits(iface))
-	      iface.editable = False
+              iface.devclass = self.detect_dev_class(iface)
+              iface.up = shell_status('ifconfig ' + iface.name + '|grep UP') == 0
+              iface.get_bits(self.app, self.detect_iface_bits(iface))
+        else:
+            s = shell('ip -o link list')
+                for line in s.split('\n'):
+                    line = line.strip()
+                    if line != '':
+                        name = line.split(':')[1].strip()
+                        iface = NetworkInterface()
+                        iface.name = name
+                        self.interfaces[name] = iface
+                        iface.devclass = self.detect_dev_class(iface)
+                        iface.up = (line.find('state UP') != -1)
+                        iface.get_bits(self.app, self.detect_iface_bits(iface))
+                        iface.editable = False
    
 
     def save(self):

--- a/plugins/network/nctp_ip.py
+++ b/plugins/network/nctp_ip.py
@@ -33,7 +33,7 @@ class LinuxIp(Plugin):
         
     def get_tx(self, iface):
         s = shell('ip -s link ls %s' % iface.name)
-	s = s.split('\n')[5]
+        s = s.split('\n')[5]
         try:
             s = s.split()[0]
         except:
@@ -42,7 +42,7 @@ class LinuxIp(Plugin):
     
     def get_rx(self, iface):
         s = shell('ip -s link ls %s' % iface.name)
-	s = s.split('\n')[3]
+        s = s.split('\n')[3]
         try:
             s = s.split()[0]
         except:

--- a/plugins/network/nctp_ip.py
+++ b/plugins/network/nctp_ip.py
@@ -1,0 +1,104 @@
+import time
+
+from ajenti.com import *
+from ajenti.ui import *
+from ajenti.utils import shell, str_fsize
+
+
+class LinuxIp(Plugin):
+    platform = ['Arch']
+
+    def get_info(self, iface):
+        ui = UI.Container( 
+            UI.Formline(
+                UI.HContainer(
+                    UI.Image(file='/dl/network/%s.png'%('up' if iface.up else 'down')),
+                    UI.Label(text=iface.name, bold=True)
+                ),
+                text='Interface',
+            ),
+            UI.Formline(
+                UI.Label(text=self.get_ip(iface)),
+                text='Address',
+            ),
+            UI.Formline(
+                UI.Label(text='Up %s, down %s' % (
+                    str_fsize(self.get_tx(iface)),
+                    str_fsize(self.get_rx(iface)),
+                )),
+                text='Traffic',
+            ),
+        )
+        return ui
+        
+    def get_tx(self, iface):
+        s = shell('ip -s link ls %s' % iface.name)
+	s = s.split('\n')[5]
+        try:
+            s = s.split()[0]
+        except:
+            s = '0'
+        return int(s)
+    
+    def get_rx(self, iface):
+        s = shell('ip -s link ls %s' % iface.name)
+	s = s.split('\n')[3]
+        try:
+            s = s.split()[0]
+        except:
+            s = '0'
+        return int(s)
+        
+    def get_ip(self, iface):
+        s = shell('ip addr list %s | grep \'inet\''%iface.name)
+        try:
+            s = s.split()[1]
+        except:
+            s = '0.0.0.0'
+        return s    
+        
+
+    def detect_dev_class(self, iface):
+        if iface.name[:-1] in ['ppp', 'wvdial']:
+            return 'ppp'
+        if iface.name[:-1] in ['wlan', 'ra', 'wifi', 'ath']:
+            return 'wireless'
+        if iface.name[:-1] == 'br':
+            return 'bridge'
+        if iface.name[:-1] == 'tun':
+            return 'tunnel'
+        if iface.name == 'lo':
+            return 'loopback'
+        if iface.name[:-1] == 'eth':
+            return 'ethernet'
+        return ''
+
+    def detect_iface_bits(self, iface):
+        r = ['linux-basic']
+        cls = self.detect_dev_class(iface)
+        if iface.type == 'inet' and iface.addressing == 'static':
+            r.append('linux-ipv4')
+        if iface.type == 'inet6' and iface.addressing == 'static':
+            r.append('linux-ipv6')
+        if iface.addressing == 'dhcp':
+            r.append('linux-dhcp')
+        if cls == 'ppp':
+            r.append('linux-ppp')
+        if cls == 'wireless':
+            r.append('linux-wlan')
+        if cls == 'bridge':
+            r.append('linux-bridge')
+        if cls == 'tunnel':
+            r.append('linux-tunnel')
+
+        r.append('linux-ifupdown')
+        return r
+        
+    def up(self, iface):
+        shell('ip link set dev %s up' % iface.name)
+        time.sleep(1)
+
+    def down(self, iface):
+        shell('ip link set dev %s down' % iface.name)
+        time.sleep(1)
+        


### PR DESCRIPTION
ifconfig has been depricated, and is not installed by default on arch
any more.
This patch makes network plugin use "ip" on arch.
It also makes it work with arch users who do not set up their network
with rc.conf (i.e. network manger).
## 

Don't know if this is helpful to anyone but got things working on my machine.
