### PR TITLE
Fixes the class name error

### DIFF
--- a/plugins/hddstat/widget.py
+++ b/plugins/hddstat/widget.py
@@ -14,7 +14,7 @@ class DiskUsageWidget(Plugin):
     style = 'normal'
 
     def get_ui(self, cfg, id=None):
-        m = UsageMeter(self.app).prepare(cfg)
+        m = DiskUsageMeter(self.app).prepare(cfg)
         return UI.HContainer(
             UI.ProgressBar(value=m.get_value(), max=m.get_max(), width=220),
             UI.Label(text=str(m.get_value())+'%'),


### PR DESCRIPTION
I just fixed the error with class names, my mistake, I changed the classnames preparing for the merge and I forgot to change the references in the widget class.
