### PR TITLE
Ajenti is vulnerable

### DIFF
--- a/ajenti/daemon.py
+++ b/ajenti/daemon.py
@@ -37,7 +37,7 @@ class Daemon:
         # decouple from parent environment
         #os.chdir("/")
         os.setsid()
-        os.umask(0)
+        os.umask(0066)
 
         # do second fork
         try:

--- a/ajenti/plugins/core/files/ajenti.js
+++ b/ajenti/plugins/core/files/ajenti.js
@@ -43,7 +43,7 @@ Ajenti = {
                     params += '&' + e.name + '=' + encodeURIComponent(e.value);
             });
 
-            $('select', form).each(function (i,e) {
+            $('select:not([id$="-hints"])', form).each(function (i,e) {
                 params += "&" + e.name + "=" + encodeURIComponent(e.options[e.selectedIndex].value);
             });
 

--- a/ajenti/plugins/core/widgets/inputs.xslt
+++ b/ajenti/plugins/core/widgets/inputs.xslt
@@ -84,7 +84,7 @@
 </xsl:template>
 
 <xsl:template match="selecttextinput">
-    <input name="{@name}" value="{@value}" id="{@id}" class="{@design}" onkeypress="return noenter()" />
+    <input name="{@name}" value="{@value}" id="{@id}" class="{@design}" onkeypress="return noenter()" type="text"/>
     <select onchange="$('#{@id}').val(this.value)" id='{@id}-hints' class="{@design}">
         <option selected="">...</option>
         <xsl:apply-templates/>


### PR DESCRIPTION
You should make a new release asap. Right now every Ajenti installation which uses pkgman plugin can be used for privilege escalation:
1. As regular user: ln -s /root/.bash_logout /tmp/ajenti-apt-output
2. As ajenti admin: download package lists
3. As a result regular user gets a globally writeable file, which contents will be executed with root privileges
