### PR TITLE
fix services not reported as running in archlinux

### DIFF
--- a/plugins/services/s_arch.py
+++ b/plugins/services/s_arch.py
@@ -11,7 +11,6 @@ class ArchServiceManager(Plugin):
 
     def list_all(self):
         r = []
-        running = os.listdir('/var/run/daemons')
         for s in os.listdir('/etc/rc.d'):
             svc = apis.services.Service()
             svc.name = s
@@ -21,8 +20,8 @@ class ArchServiceManager(Plugin):
         return sorted(r, key=lambda s: s.name)
 
     def get_status(self, name):
-        s = shell('/etc/rc.d/' + name + ' status')
-        return 'running' if 'running' in s else 'stopped'
+        running = os.listdir('/var/run/daemons')
+        return 'running' if name in running else 'stopped'
 
     def start(self, name):
         shell('/etc/rc.d/' + name + ' start')


### PR DESCRIPTION
The 'get_status' method of the services plugin determined the status of running
daemons via the status function of the daemon scripts. Unfortunately not all
daemon scripts implement this method (e.g. dnsmasq, sshd, nginx,...).
Listing the files in /var/run/daemons/ is a more robust method.
