### PR TITLE
Extend hddstat

### DIFF
--- a/plugins/hddstat/layout/widget-config.xml
+++ b/plugins/hddstat/layout/widget-config.xml
@@ -1,0 +1,6 @@
+<xml>
+    <dialogbox id="dlgWidgetConfig">
+        <label size="2" text="Select disk" />
+        <selectinput name="disk" id="list" />
+    </dialogbox>
+</xml>

--- a/plugins/hddstat/usage.py
+++ b/plugins/hddstat/usage.py
@@ -1,26 +1,54 @@
 from ajenti.api import *
 from ajenti.utils import shell
+import os
+import re
 
 class DiskUsageMeter(LinearMeter):
     name = 'Disk usage'
     category = 'System'
     transform = 'percent'
-   
-    def get_usage(self, dev):
-        u = shell('df --total | grep -w %s' % dev)
-        if dev == 'total':
-            u = int(u.split().pop().strip('%'))
+
+    _partstatformat = re.compile('(/dev/)?(?P<dev>\w+)\s+\d+\s+\d+\s+\d+\s+' +
+                                       '(?P<usage>\d+)%\s+(?P<mountpoint>\S+)$')
+    _totalformat = re.compile('(?P<dev>total)\s+\d+\s+\d+\s+\d+\s+(?P<usage>\d+)%$')
+
+    def init(self):
+        if self.variant == 'total':
+            self.text = 'total'
         else:
-            u = int(u.split().pop(-2).strip('%'))
-        return u
-    
-    def get_value(self, dev):
-        return self.get_usage(dev)
-    
+            mountpoints = self.get_mountpoints()
+            self.text = '%s (%s)' % (self.variant, ', '.join(mountpoints))
+
+    def _get_stats(self, predicate = (lambda m: True)):
+        if hasattr(self, 'variant') and self.variant == 'total':
+            matcher = DiskUsageMeter._totalformat
+        else:
+            matcher = DiskUsageMeter._partstatformat
+
+        stats = shell('df --total')
+        matches = []
+        for stat in stats.splitlines():
+            match = matcher.match(stat)
+            if match and predicate(match):
+                matches.append(match)
+        return matches
+
+    def _get_stats_for_this_device(self):
+        return self._get_stats(lambda m: m.group('dev').endswith(self.variant))
+
+    def get_variants(self):
+        return sorted(set([ m.group('dev') for m in self._get_stats()])) + ['total']
+
+    def get_mountpoints(self):
+        devmatches = self._get_stats_for_this_device()
+        return sorted([ m.group('mountpoint') for m in devmatches])
+
+    def get_value(self):
+        devmatches = self._get_stats_for_this_device()
+        return int(devmatches[0].group('usage'))
+
     def get_min(self):
         return 0
-    
+
     def get_max(self):
         return 100
-
-

--- a/plugins/hddstat/widget.py
+++ b/plugins/hddstat/widget.py
@@ -14,31 +14,28 @@ class DiskUsageWidget(Plugin):
     style = 'normal'
 
     def get_ui(self, cfg, id=None):
+        self.title = '%s Disk Usage' % cfg
         if cfg == None:
             cfg = "total"
         m = DiskUsageMeter(self.app).prepare(cfg)
         return UI.HContainer(
-            UI.ProgressBar(value=m.get_value(cfg), max=m.get_max(), width=220),
-            UI.Label(text=str('%s : %d %%' % (cfg,  m.get_value(cfg)))),
+            UI.ProgressBar(value=m.get_value(), max=m.get_max(), width=220),
+            UI.Label(text=str('%d%%' % m.get_value())),
         )
 
     def handle(self, event, params, cfg, vars=None):
         pass
 
     def get_config_dialog(self):
-        mgr = self.app.get_backend(apis.services.IServiceManager)
-        dlg = self.app.inflate('hddstat:widget-config')
-        u = shell('df --total').split('\n')[1:-2];
-        u.append ('total')
-        for y in u:
-            s = y.split()
-            s = s.pop()
-            dlg.append('list', UI.SelectOption(
-                value=s,
-                text=s,
+        usageMeter = DiskUsageMeter(self.app)
+        dialog = self.app.inflate('hddstat:widget-config')
+        for option in usageMeter.get_variants():
+            dialog.append('list', UI.SelectOption(
+                value=option,
+                text=option,
             ))
-        return dlg
-   
- 
+        return dialog
+
+
     def process_config(self, vars):
-        return vars.getvalue('svc', None)
+        return vars.getvalue('disk', None)


### PR DESCRIPTION
Extend the functionality of the hddstat-plugin:
Add options to choose for which partition the widget shall display disk usage information and add health-variants to configure constraints separately for each partition.
