### PR TITLE
Implement salted hashing using passlib

### DIFF
--- a/ajenti/plugins/core/templates/auth.xml
+++ b/ajenti/plugins/core/templates/auth.xml
@@ -19,7 +19,6 @@
                 </div>
                 <div class="modal-content">
                     <br/>
-                    <input type="hidden" id="challenge" />
                     <div class="clearfix">
                         <hlabel for="username" text="Username" />
                         <div class="input">
@@ -45,14 +44,12 @@ Ajenti.UI.showAsModal('auth-dialog');
 $('#username').focus()
 $('#form').submit(function (e) {
     e.preventDefault();
-    var h = Sha1.hash($('#password').val());
-    var r = Sha1.hash($('#challenge').val() + h);
     $.ajax({
         url: '/auth',
         type: 'POST',
         data: {
             username: $('#username').val(),
-            response: r
+            response: $('#password').val()
         },
         success: function () {
             Ajenti.UI.hideModal('auth-dialog');

--- a/ajenti/utils/utils.py
+++ b/ajenti/utils/utils.py
@@ -6,6 +6,7 @@ import urllib
 from datetime import datetime
 from hashlib import sha1
 from base64 import b64encode
+from passlib.hash import sha512_crypt
 
 
 def enquote(s):
@@ -146,11 +147,16 @@ def shell_stdin(c, input):
     return p.communicate(input)
 
 
-def hashpw(passw):
+def hashpw(passw, scheme = 'sha512_crypt'):
     """
-    Returns a Base64-encoded SHA1 digest of given password.
+    Returns a hashed form of given password. Default scheme is
+    sha512_crypt.
     """
-    return '{SHA}' + b64encode(sha1(passw).digest())
+    if scheme == 'sha512_crypt':
+        return sha512_crypt.encrypt(passw)
+    elif scheme == 'sha':
+        return '{SHA}' + b64encode(sha1(passw).digest())
+    return sha512_crypt.encrypt(passw)
 
 def str_fsize(sz):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+greenlet
+gevent
+lxml
+passlib
+#feedparser [NEWS]
+#psutil [TASKS]
+#beautifulsoup [MUNIN]
+#setuptools [BUILD]
+#sphinx [DOCS]


### PR DESCRIPTION
Should fix https://bugs.launchpad.net/ajenti/+bug/1048313

Default admin `{SHA}` hash has been left in `ajenti.conf`, however this will be changed if admin password is changed. I did not know the admin password that hash represents.

Old `{SHA}` hashes are still supported, but new users will use sha512_crypt, which is a salted [PBKDF](http://en.wikipedia.org/wiki/Key_derivation_function) originally used for unix user accounts.

Challenge-response mechanism was removed to support this, as it would require implementing whichever new PBKDF was chosen in javascript again, and is insecure anyway, since it can be MITMed. Users wishing secure their login should use https on the server.

If this patch is accepted, would recommend:
- Updating the hardcoded admin hash in ajenti.conf
- Updating documentation to ask users to use https in order to secure their login/session/server.
- sha1.js and base64.js no longer needed, wasn't sure where they are included

I also added a `requirements.txt`, this is very useful if using python's pip installation, and/or virtualenv in development. It simply lists the necessary python packages for the project. AFAIK, [passlib](http://pypi.python.org/pypi/passlib/1.6.1) could also be specified in setup.py

Thanks
