### PR TITLE
Fix import random, add requirements.txt

### DIFF
--- a/ajenti/__init__.py
+++ b/ajenti/__init__.py
@@ -29,6 +29,7 @@ import build
 import subprocess
 import os
 import platform
+import random
 
 
 def detect_version():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+python-daemon
+passlib
+gevent-socketio


### PR DESCRIPTION
allows `pip install -r requirements.txt` to easily get required packages from pypi
