### PR TITLE
utils.py shell routine - add LANG=C to commandline

### DIFF
--- a/ajenti/utils/utils.py
+++ b/ajenti/utils/utils.py
@@ -98,7 +98,7 @@ def shell(c, stderr=False):
     """
     Runs commandline in the default shell and returns output. Blocking.
     """
-    p = subprocess.Popen('LC_ALL=C '+c, shell=True,
+    p = subprocess.Popen('LANG=C LC_ALL=C '+c, shell=True,
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE)
 


### PR DESCRIPTION
LC_ALL=C is not enough in CentOS to force English command output. 
## Here is my testcase:

[root@vps ~]# cat /etc/redhat-release 
CentOS release 5.9 (Final)

[root@vps ~]# locale
LANG=uk_UA.UTF-8
LC_CTYPE="uk_UA.UTF-8"
LC_NUMERIC="uk_UA.UTF-8"
LC_TIME="uk_UA.UTF-8"
LC_COLLATE="uk_UA.UTF-8"
LC_MONETARY="uk_UA.UTF-8"
LC_MESSAGES="uk_UA.UTF-8"
LC_PAPER="uk_UA.UTF-8"
LC_NAME="uk_UA.UTF-8"
LC_ADDRESS="uk_UA.UTF-8"
LC_TELEPHONE="uk_UA.UTF-8"
LC_MEASUREMENT="uk_UA.UTF-8"
LC_IDENTIFICATION="uk_UA.UTF-8"
LC_ALL=

[root@vps ~]# LC_ALL=C service nginx status
nginx (pid  2722) виконується...

[root@vps ~]# LANG=C LC_ALL=C service nginx status
nginx (pid  2722) is running...

---
