### PR TITLE
[arch] update hosts and iptables for systemd compat 

### DIFF
--- a/plugins/hosts/__init__.py
+++ b/plugins/hosts/__init__.py
@@ -1,6 +1,6 @@
 MODULES = ['main', 'backend']
 
-DEPS = [(['freebsd', 'centos', 'arch', 'gentoo', 'mandriva'],
+DEPS = [(['freebsd', 'centos', 'gentoo', 'mandriva'],
          [
            ('plugin', 'lib_rcconf'),
          ]

--- a/plugins/hosts/backend.py
+++ b/plugins/hosts/backend.py
@@ -85,10 +85,10 @@ class ArchHostnameManager(Plugin):
     platform = ['arch']
 
     def gethostname(self):
-        return apis.rcconf.RCConf(self.app).get_param('HOSTNAME')
+        return open('/etc/hostname').read()
 
     def sethostname(self, hn):
-        apis.rcconf.RCConf(self.app).set_param('HOSTNAME', hn, near='HOSTNAME')
+        open('/etc/hostname', 'w').write(hn)
 
 
 class BSDHostnameManager(Plugin):


### PR DESCRIPTION
The hosts and iptables plugins still rely on the old rc.d system, which Arch Linux no longer supports. This pull makes these plugins functional again:
- hosts simply edits the /etc/hostname file instead
- iptables "autostarts" via systemd symlink instead of rc.d entry
