### PR TITLE
exempt localhost from SSL warning message

### DIFF
--- a/ajenti/plugins/main/content/js/ajenti.coffee
+++ b/ajenti/plugins/main/content/js/ajenti.coffee
@@ -383,7 +383,7 @@ $.fn.safeRemove = () ->
 #---------------------
 
 $(() ->
-    if location.protocol == 'https:'
+    if location.protocol == 'https:' or location.hostname == 'localhost'
         $('#ssl-alert').hide()
 )
 


### PR DESCRIPTION
SSL is unnecessary when using ajenti through localhost/SSH tunnel.
