### PR TITLE
Recognize Fedora and XO systems (OLPC) platform

### DIFF
--- a/ajenti/__init__.py
+++ b/ajenti/__init__.py
@@ -59,6 +59,8 @@ def detect_platform():
         'redhat enterprise linux': 'rhel',
         'red hat enterprise linux server': 'rhel',
         'fedora': 'rhel',
+        'olpc': 'rhel',
+        'xo-system': 'rhel',
     }
 
     platform_mapping = {

--- a/ajenti/__init__.py
+++ b/ajenti/__init__.py
@@ -58,6 +58,7 @@ def detect_platform():
         'linuxmint': 'ubuntu',
         'redhat enterprise linux': 'rhel',
         'red hat enterprise linux server': 'rhel',
+        'fedora': 'rhel',
     }
 
     platform_mapping = {


### PR DESCRIPTION
Those platforms aren't recognize by ajenti currently. They are Red Hat like distros.

_Fedora 18_

```
$ uname --all
Linux schoolserver 3.8.4-202.fc18.i686.PAE #1 SMP Thu Mar 21 17:14:12 UTC 2013 i686 i686 i386 GNU/Linux
$ python -c "import platform; print platform.linux_distribution()" 
('Fedora', '18', 'Spherical Cow')
```

_OLPC XO-4_

```
$ uname --all
Linux new-host 3.5.7_xo4-20130308.1209.olpc.66ac429 #1 PREEMPT Fri Mar 8 12:21:27 EST 2013 armv7l armv7l armv7l GNU/Linux
[olpc@new-host ~]$ python -c "import platform; print platform.linux_distribution()" 
('XO-system ', '1', 'build 17) (based on Fedora 18')
```

_OLPC XO-1.75_

```
$ python -c "import platform; print platform.linux_distribution()" 
('OLPC', '13', 'based on Fedora 18')
```

_OLPC XO-1_

```
$ python -c "import platform; print platform.linux_distribution()" 
('OLPC', '4', 'based on Fedora 18')
```
