### PR TITLE
Minor bugfixes for FreeBSD 10.0-RELEASE

### DIFF
--- a/ajenti/plugins/samba/main.py
+++ b/ajenti/plugins/samba/main.py
@@ -29,7 +29,11 @@ class Samba (SectionPlugin):
 
         self.binder = Binder(None, self.find('config'))
         self.find('shares').new_item = lambda c: ShareData()
-        self.config = SambaConfig(path='/etc/samba/smb.conf')
+        self.config = SambaConfig(
+                                  path=platform_select(
+                                                       default='/etc/samba/smb.conf',
+                                                       freebsd='/usr/local/etc/smb.conf')
+                                  )
 
         def post_item_bind(object, collection, item, ui):
             ui.find('disconnect').on('click', self.on_disconnect, item)

--- a/ajenti/plugins/sensors/uptime.py
+++ b/ajenti/plugins/sensors/uptime.py
@@ -30,6 +30,7 @@ class BSDUptimeSensor (Sensor):
         https://github.com/Cairnarvon/uptime/blob/master/src/__init__.py
         """
 
+
         try:
             libc = ctypes.CDLL('libc.so')
         except AttributeError:
@@ -80,4 +81,7 @@ class UptimeWidget (DashboardWidget):
 
         self.find('icon').text = 'off'
         self.find('name').text = 'Uptime'
-        self.find('value').text = str_timedelta(self.sensor.value())
+        if not self.sensor.value() is None:
+            self.find('value').text = str_timedelta()
+        else:
+            self.find('value').text = "Error gathering System Uptime."


### PR DESCRIPTION
Fixed 2 bugs:
- Uptime Widget crashed on load due to the fact that Libc is probably missing or no longer GCC but CLANG in FreeBSD 10
- Fixed Samba Config location (FreeBSD uses /usr/local/ for user services/applications, hence smb.conf is located in /usr/local/etc/smb.conf)
