### PR TITLE
Ensuring that scripted install works in Debian/Ubuntu

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -14,6 +14,6 @@ echo ':: Updating lists'
 apt-get update
 
 echo ':: Installing package'
-apt-get install ajenti
+apt-get install -y ajenti
 
 echo ':: Done! Open https://<address>:8000 in browser'

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -14,6 +14,6 @@ echo ':: Updating lists'
 apt-get update
 
 echo ':: Installing package'
-apt-get install ajenti
+apt-get install -y ajenti
 
 echo ':: Done! Open https://<address>:8000 in browser'


### PR DESCRIPTION
Currently, the install script aborts since the user has to accept the install with "Y." Using the command line argument to apt-get install -y to fix this.
