### PR TITLE
systemd fix: force detach daemon

### DIFF
--- a/ajenti-panel
+++ b/ajenti-panel
@@ -80,6 +80,7 @@ if __name__ == '__main__':
             pidfile=PidFile('/var/run/ajenti.pid'),
             stdout=open('/dev/null', 'w+'),
             stderr=open('/dev/null', 'w+'),
+            detach_process=True
         )
         with context:
             ajenti.log.init_log_rotation()


### PR DESCRIPTION
The problem with systemd and daemon module, is when it tries to auto-detect `detach_process` flag it sets it to `False` when run by systemd, making things hang up during daemon start.

This commit fixes this behavior by forcing `detach_process` behavior.
