### PR TITLE
fix formgroup last line padding and make checkbox text label active

### DIFF
--- a/ajenti/plugins/main/content/js/controls.inputs.coffee
+++ b/ajenti/plugins/main/content/js/controls.inputs.coffee
@@ -111,7 +111,7 @@ class window.Controls.checkbox extends window.Control
                         <i class="icon-ok"></i>
                     </div>
                 </label>
-                <div class="control label">#{@s(@properties.text)}</div>
+                <label for="#{@properties.uid}" class="control label">#{@s(@properties.text)}</label>
             </div>
         """
 


### PR DESCRIPTION
I noticed there's an ugly space above last formline in formgroups, I don't think this was an indented UI decision, I guess you really meant to add some space below last formline in formgroups.

Here's a fix for it. If the paddings are intended, feel free to reject it =)
