### PR TITLE
pass style argument to pathbox input

### DIFF
--- a/ajenti/plugins/main/content/js/controls.inputs.coffee
+++ b/ajenti/plugins/main/content/js/controls.inputs.coffee
@@ -313,7 +313,7 @@ class window.Controls.pathbox extends window.Control
 
     setupDom: (dom) ->
         super(dom)
-        @textbox = new Controls.textbox(@ui, value: @properties.value).setupDom()
+        @textbox = new Controls.textbox(@ui, style: @properties.style, value: @properties.value).setupDom()
         @button = new Controls.button(
             @ui, 
             style: 'mini'


### PR DESCRIPTION
I needed long version of pathbox field, so I tried to apply style="big" attribute to it, like with textbox, but it didn't work. Hence the patch to pass style attribute to underlying textbox of pathbox widget.
