### PR TITLE
pass textbox type property to dom

### DIFF
--- a/ajenti/plugins/main/content/js/controls.inputs.coffee
+++ b/ajenti/plugins/main/content/js/controls.inputs.coffee
@@ -3,7 +3,7 @@ class window.Controls.textbox extends window.Control
         """
             <input class="control textbox #{@s(@properties.style)}"
                     #{if @properties.readonly then 'readonly' else ''}
-                    type="text" />
+                    type="#{@properties.type}" />
         """
 
     setupDom: (dom) ->


### PR DESCRIPTION
Textbox widget has a type property, but doesn't make use of it. The patch fixes the issue.
