### PR TITLE
make ldap library dependency optional

### DIFF
--- a/ajenti/usersync/__init__.py
+++ b/ajenti/usersync/__init__.py
@@ -1,5 +1,5 @@
 from base import UserSyncProvider
-from adsync import ActiveDirectorySyncProvider
 from local import AjentiSyncProvider
 from unix import UNIXSyncProvider
+from adsync import ActiveDirectorySyncProvider
 from ldapsync import LDAPSyncProvider

--- a/ajenti/usersync/adsync.py
+++ b/ajenti/usersync/adsync.py
@@ -1,4 +1,7 @@
-import ldap
+try:
+    import ldap
+except ImportError:
+    ldap = None
 
 import ajenti
 from ajenti.api import *
@@ -34,13 +37,19 @@ class ActiveDirectorySyncProvider (UserSyncProvider, BasePlugin):
     classconfig_editor = ADSyncClassConfigEditor
 
     def __get_ldap(self):
+        if not ldap:
+            return None
+
         c = ldap.initialize('ldap://' + self.classconfig['address'])
         c.bind_s('%s\\%s' % (self.classconfig['domain'], self.classconfig.get('user', 'Administrator')), self.classconfig['password'])
         c.set_option(ldap.OPT_REFERRALS, 0)
         return c
 
     def test(self):
-        self.__search()
+        try:
+            return bool(self.__search())
+        except:
+            return False
 
     def check_password(self, username, password):
         l = self.__get_ldap()

--- a/ajenti/usersync/adsync.py
+++ b/ajenti/usersync/adsync.py
@@ -36,6 +36,9 @@ class ActiveDirectorySyncProvider (UserSyncProvider, BasePlugin):
     classconfig_root = True
     classconfig_editor = ADSyncClassConfigEditor
 
+    def verify(self):
+        return ldap is not None
+
     def __get_ldap(self):
         if not ldap:
             return None
@@ -46,10 +49,7 @@ class ActiveDirectorySyncProvider (UserSyncProvider, BasePlugin):
         return c
 
     def test(self):
-        try:
-            return bool(self.__search())
-        except:
-            return False
+        self.__search()
 
     def check_password(self, username, password):
         l = self.__get_ldap()

--- a/ajenti/usersync/ldapsync.py
+++ b/ajenti/usersync/ldapsync.py
@@ -1,4 +1,7 @@
-import ldap
+try:
+    import ldap
+except ImportError:
+    ldap = None
 
 import ajenti
 from ajenti.api import *
@@ -33,6 +36,9 @@ class LDAPSyncProvider (UserSyncProvider):
     classconfig_editor = LDAPSyncClassConfigEditor
 
     def __get_ldap(self):
+        if not ldap:
+            return None
+
         c = ldap.initialize(self.classconfig['url'])
         c.bind_s(self.classconfig['admin_dn'], self.classconfig['secret'])
         return c

--- a/ajenti/usersync/ldapsync.py
+++ b/ajenti/usersync/ldapsync.py
@@ -43,6 +43,9 @@ class LDAPSyncProvider (UserSyncProvider):
         c.bind_s(self.classconfig['admin_dn'], self.classconfig['secret'])
         return c
 
+    def verify(self):
+        return ldap is not None
+
     def test(self):
         return self.__get_ldap() is not None
 


### PR DESCRIPTION
I don't have LDAP installed on by linuxbox, neither I want to use it, so I don't need python ldap library. And as it's not installed, Ajenti usersync modules which depend on LDAP (ActiveDirectory and LDAP) fail with `ImportError`. This is not nice, besides I think I'm not the only one who doesn't use LDAP but want to use Ajenti. The patch makes python-ldap dependency optional by catching `ImportError` and refusing to load usersync classes which depend on ldap if it's not available.

Also I noticed inconsistency in `ajenti.usersync.ActiveDirectorySyncProvider.test()` method, so I changed it to reflect the obvious intent of the code. I'm not sure it's correct fix, so please feel free to give me feedback on it. Thank you.
