### PR TITLE
fix incorrect python module deps processing in installer plugin

### DIFF
--- a/ajenti/plugins/packages/installer.py
+++ b/ajenti/plugins/packages/installer.py
@@ -28,7 +28,7 @@ class PackageInstaller (UIElement, BasePlugin):
                 self.visible = True
                 Binder(self, self).populate()
             if self.package.startswith('python-module-'):
-                d = ModuleDependency(self.package[len('python-module-')])
+                d = ModuleDependency(self.package[len('python-module-'):])
             else:
                 d = BinaryDependency(self.package)
             if d.satisfied():


### PR DESCRIPTION
While wandering over source code, I found an obvious bug in module dependency processing in installer plugin. The fix is in the PR.
