### PR TITLE
Fix for Centos 6.x systems - without the epel repo, easy_install fails a...

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,7 @@ echo ":: Distro: $DISTRO"
 
 if [ "$OS" == "rhel" ] ; then
     echo ":: Installing prerequisites"
+	yum install -y epel*
     yum install -y gcc python-devel python-pip libxslt-devel libxml2-devel libffi-devel openssl-devel libjpeg-turbo-devel libpng-devel dbus-python || exit 1
 fi
 


### PR DESCRIPTION
Eugene,

Threw in a small fix that throws the whole script off in Centos 6.x - The epel repo has to be installed ( and separately ) in order for this script to complete, otherwise easy_install goes into a fit. 
