### PR TITLE
additional typical LDAP group to query

### DIFF
--- a/ajenti/usersync/ldapsync.py
+++ b/ajenti/usersync/ldapsync.py
@@ -63,7 +63,7 @@ class LDAPSyncProvider (UserSyncProvider):
         users = l.search_s(
             self.classconfig['auth_dn'],
             ldap.SCOPE_SUBTREE,
-            '(|(objectClass=user)(objectClass=simpleSecurityObject))',
+            '(|(objectClass=user)(objectClass=simpleSecurityObject)(objectClass=inetOrgPerson))',
             ['cn']
         )
         for u in users:


### PR DESCRIPTION
This group is used in many LDAP setups / schemas, therefore you should query for it as well, otherwise, users will not get listed.
