### PR TITLE
Some changes in installation scripts

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -8,7 +8,7 @@ echo ':: Installing repo key'
 wget http://repo.ajenti.org/debian/key -O- | apt-key add -
 
 echo ':: Adding repo entry'
-echo "deb http://repo.ajenti.org/debian main main debian" >> /etc/apt/sources.list.d/ajenti.list
+echo "deb http://repo.ajenti.org/debian main main debian" > /etc/apt/sources.list.d/ajenti.list
 
 echo ':: Updating lists'
 apt-get update

--- a/scripts/install-raspbian.sh
+++ b/scripts/install-raspbian.sh
@@ -8,7 +8,7 @@ echo ':: Installing repo key'
 wget http://repo.ajenti.org/debian/key -O- | apt-key add -
 
 echo ':: Adding repo entry'
-echo "deb http://repo.ajenti.org/debian main main debian" >> /etc/apt/sources.list.d/ajenti.list
+echo "deb http://repo.ajenti.org/debian main main debian" > /etc/apt/sources.list.d/ajenti.list
 
 echo ':: Updating lists'
 apt-get update

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -8,7 +8,7 @@ echo ':: Installing repo key'
 wget http://repo.ajenti.org/debian/key -O- | apt-key add -
 
 echo ':: Adding repo entry'
-echo "deb http://repo.ajenti.org/debian main main ubuntu" >> /etc/apt/sources.list.d/ajenti.list
+echo "deb http://repo.ajenti.org/debian main main ubuntu" > /etc/apt/sources.list.d/ajenti.list
 
 echo ':: Updating lists'
 apt-get update


### PR DESCRIPTION
Prevent duplicate sources.

Scenario Example:

Ubuntu:

`W: Duplicate sources.list entry http://repo.ajenti.org/debian/ main/ubuntu amd64 Packages (/var/lib/apt/lists/repo.ajenti.org_debian_dists_main_ubuntu_binary-amd64_Packages)`
