### PR TITLE
Feature/user folder isolation

### DIFF
--- a/ajenti/plugins/fm/fm.py
+++ b/ajenti/plugins/fm/fm.py
@@ -30,6 +30,29 @@ class FileManager (SectionPlugin):
     classconfig_root = True
 
     def init(self):
+
+        _username = self.context.user.name
+
+        # Set config per user if isolate is enabled
+        if self.classconfig['isolate'] and _username != 'root':
+            self.classconfig_root = False
+            # Set root and start dir
+            rootpath = os.path.join(self.classconfig['root'], _username)
+            self.classconfig['root'] = rootpath
+            self.classconfig['start'] = rootpath
+
+            # Check if dir exists and if not create
+            if not os.path.isdir(rootpath):
+                # Check if it exists as file and rename
+                if os.path.isfile(rootpath):
+                    _newpath = rootpath.split('/')
+                    _newpath[-1] = '.' + _newpath[-1] + '.bak'
+                    _newpath = '/'.join(_newpath)
+                    os.rename(rootpath, _newpath)
+
+                os.makedirs(rootpath, 0775)
+                self._chown_new(rootpath)
+
         self.title = _('File Manager')
         self.category = _('Tools')
         self.icon = 'folder-open'

--- a/ajenti/plugins/fm/layout/config.xml
+++ b/ajenti/plugins/fm/layout/config.xml
@@ -12,5 +12,8 @@
         <formline text="{Group for new files}">
             <textbox bind="[new_group]" />
         </formline>
+        <formline text="{Isolated user subfolders}">
+            <checkbox bind="[isolate]" text="{Enable}" />
+        </formline>
     </vc>
 </box>

--- a/ajenti/plugins/fm/layout/config.xml
+++ b/ajenti/plugins/fm/layout/config.xml
@@ -12,7 +12,7 @@
         <formline text="{Group for new files}">
             <textbox bind="[new_group]" />
         </formline>
-        <formline text="{Isolated user subfolders}">
+        <formline text="{Isolate users}">
             <tooltip text="{Subfolders of the topmost directory will be created and set for every user.}">
                 <checkbox bind="[isolate]" text="{Enable}" />
             </tooltip>

--- a/ajenti/plugins/fm/layout/config.xml
+++ b/ajenti/plugins/fm/layout/config.xml
@@ -13,7 +13,9 @@
             <textbox bind="[new_group]" />
         </formline>
         <formline text="{Isolated user subfolders}">
-            <checkbox bind="[isolate]" text="{Enable}" />
+            <tooltip text="{Subfolders of the topmost directory will be created and set for every user.}">
+                <checkbox bind="[isolate]" text="{Enable}" />
+            </tooltip>
         </formline>
     </vc>
 </box>

--- a/ajenti/plugins/notepad/layout/config.xml
+++ b/ajenti/plugins/notepad/layout/config.xml
@@ -1,7 +1,14 @@
 <box>
     <vc binder:context="classconfig">
         <formline text="{Topmost directory}">
-            <textbox bind="[root]" />
+            <tooltip text="{If isolation is enabled enter the same as the File Manager topmost directory}">
+                  <textbox bind="[root]" />
+            </tooltip>
+        </formline>
+        <formline text="{Isolated user subfolders}">
+            <tooltip text="{This option must be enabled in the File Manager module as well.}">
+                  <checkbox bind="[isolate]" text="{Enable}" />
+            </tooltip>
         </formline>
     </vc>
 </box>

--- a/ajenti/plugins/notepad/layout/config.xml
+++ b/ajenti/plugins/notepad/layout/config.xml
@@ -1,11 +1,11 @@
 <box>
     <vc binder:context="classconfig">
         <formline text="{Topmost directory}">
-            <tooltip text="{If isolation is enabled enter the same as the File Manager topmost directory}">
+            <tooltip text="{If isolation is enabled enter the same value for the File Manager's topmost directory}">
                   <textbox bind="[root]" />
             </tooltip>
         </formline>
-        <formline text="{Isolated user subfolders}">
+        <formline text="{Isolate users}">
             <tooltip text="{This option must be enabled in the File Manager module as well.}">
                   <checkbox bind="[isolate]" text="{Enable}" />
             </tooltip>

--- a/ajenti/plugins/notepad/notepad.py
+++ b/ajenti/plugins/notepad/notepad.py
@@ -28,6 +28,20 @@ class Notepad (SectionPlugin):
     SIZE_LIMIT = 1024 * 1024 * 5
 
     def init(self):
+
+        _username = self.context.user.name
+
+        # Set config per user if isolate is enabled
+        if self.classconfig['isolate'] and _username != 'root':
+            self.classconfig_root = False
+            # Set root dir
+            rootpath = os.path.join(self.classconfig['root'], _username)
+            self.classconfig['root'] = rootpath
+
+            # Check if dir exists and set rootpath
+            if not os.path.isdir(rootpath):
+                self.classconfig['root'] = rootpath
+
         self.title = _('Notepad')
         self.icon = 'edit'
         self.category = _('Tools')

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "users": {
         "root": {
             "configs": {
-                "ajenti.plugins.notepad.notepad.Notepad": "{\"bookmarks\": [], \"root\": \"/\"}", 
+                "ajenti.plugins.notepad.notepad.Notepad": "{\"bookmarks\": [], \"root\": \"/\", \"isolate\": false}", 
                 "ajenti.plugins.terminal.main.Terminals": "{\"shell\": \"sh -c $SHELL || sh\"}", 
                 "ajenti.plugins.elements.ipmap.ElementsIPMapper": "{\"users\": {}}", 
                 "ajenti.plugins.munin.client.MuninClient": "{\"username\": \"username\", \"prefix\": \"http://localhost:8080/munin\", \"password\": \"123\"}", 
@@ -11,7 +11,7 @@
                 "ajenti.plugins.ajenti_org.main.AjentiOrgReporter": "{\"key\": null}", 
                 "ajenti.users.UserManager": "{\"sync-provider\": \"\"}", 
                 "ajenti.plugins.mysql.api.MySQLDB": "{\"password\": \"\", \"user\": \"root\", \"hostname\": \"localhost\"}", 
-                "ajenti.plugins.fm.fm.FileManager": "{\"root\": \"/\"}", 
+                "ajenti.plugins.fm.fm.FileManager": "{\"root\": \"/\", \"isolate\": false}", 
                 "ajenti.plugins.tasks.manager.TaskManager": "{\"task_definitions\": []}", 
                 "ajenti.usersync.adsync.ActiveDirectorySyncProvider": "{\"domain\": \"DOMAIN\", \"password\": \"\", \"user\": \"Administrator\", \"base\": \"cn=Users,dc=DOMAIN\", \"address\": \"localhost\"}", 
                 "ajenti.plugins.elements.usermgr.ElementsUserManager": "{\"groups\": []}", 


### PR DESCRIPTION
Added folder isolation.

In the plugin configuration an _isolate_ checkbox was added. When checked, the folder selected as root will host subdirectories named as the user, which will be used as the user's root folder.

Folders are created upon user login and if the user is _root_ the topmost directory is the one specified in the plugin.
