### PR TITLE
plugin munin: don't cache image file

### DIFF
--- a/ajenti/plugins/munin/main.py
+++ b/ajenti/plugins/munin/main.py
@@ -71,6 +71,7 @@ class MuninProxy (HttpPlugin):
                 auth=(self.client.classconfig['username'], self.client.classconfig['password'])
                ).content
         context.add_header('Content-Type', 'image/png')
+        context.add_header('Cache-Control', 'no-cache, no-store, must-revalidate')
         context.respond_ok()
         return data
 


### PR DESCRIPTION
Add do not cache to header, to prevent caching of image.

I edited that because always when i refresh my dashboard the munin images are not updated.
