### PR TITLE
Fix systemd error

### DIFF
--- a/ajenti/plugins/services/sm_systemd.py
+++ b/ajenti/plugins/services/sm_systemd.py
@@ -10,6 +10,29 @@ from ajenti.util import cache_value
 from api import Service, ServiceManager
 
 
+class SystemdService (Service):
+    source = 'systemd'
+
+    def __init__(self, name):
+        self.name = name
+        self.running = False
+
+    def refresh(self):
+        self.running = subprocess.call(['systemctl', 'is-active', self.name]) == 0
+
+    def start(self):
+        self.command('start')
+
+    def stop(self):
+        self.command('stop')
+
+    def restart(self):
+        self.command('restart')
+
+    def command(self, cmd):
+        return subprocess.call(['systemctl', cmd, self.name], close_fds=True)
+
+
 @plugin
 class SystemdServiceManager (ServiceManager):
     def init(self):
@@ -50,26 +73,3 @@ class SystemdServiceManager (ServiceManager):
                     service.running = str(unit[4]) == 'running'
 
         return r
-
-
-class SystemdService (Service):
-    source = 'systemd'
-
-    def __init__(self, name):
-        self.name = name
-        self.running = False
-
-    def refresh(self):
-        self.running = subprocess.call(['systemctl', 'is-active', self.name]) == 0
-
-    def start(self):
-        self.command('start')
-
-    def stop(self):
-        self.command('stop')
-
-    def restart(self):
-        self.command('restart')
-
-    def command(self, cmd):
-        return subprocess.call(['systemctl', cmd, self.name], close_fds=True)


### PR DESCRIPTION
This fix this error at launch : 

sm_systemd.verify(): Disabling systemd service manager: global name 'SystemdService' is not defined

Should fix definitely this issue : https://github.com/Eugeny/ajenti-v/issues/145

This also fix the dead "inactive" services witch result when you do `service php5-fpm status`, like this : 

```
● php5-fpm.service - The PHP FastCGI Process Manager
   Loaded: loaded (/lib/systemd/system/php5-fpm.service; enabled)
   Active: inactive (dead) since mar. 2015-10-27 23:31:56 CET; 1 months 24 days ago
 Main PID: 8131 (code=exited, status=0/SUCCESS)
   Status: "Processes active: 0, idle: 11, Requests: 11, slow: 0, Traffic: 0req/sec"
```
