### PR TITLE
Fix reload and restart icons

### DIFF
--- a/ajenti/plugins/apache/main.py
+++ b/ajenti/plugins/apache/main.py
@@ -14,7 +14,7 @@ class Apache(WebserverPlugin):
         {
             'command': 'force-reload',
             'text': _('Reload'),
-            'icon': 'step-forward',
+            'icon': 'reload',
         }
     ]
     hosts_available_dir = platform_select(

--- a/ajenti/plugins/bind9/layout/main.xml
+++ b/ajenti/plugins/bind9/layout/main.xml
@@ -6,7 +6,7 @@
             [{
                 'command': 'force-reload',
                 'text': _('Reload'),
-                'icon': 'step-forward',
+                'icon': 'reload',
             }]
         " />
     <body>

--- a/ajenti/plugins/main/content/css/icons.i.less
+++ b/ajenti/plugins/main/content/css/icons.i.less
@@ -312,6 +312,10 @@ ul.icons {
 .icon-eject:before {
   content: "\f052";
 }
+.icon-reload:before,
+.icon-restart:before {
+  content: "\f021";
+}
 .icon-chevron-left:before {
   content: "\f053";
 }

--- a/ajenti/plugins/mysql/main.py
+++ b/ajenti/plugins/mysql/main.py
@@ -19,7 +19,7 @@ class MySQLPlugin (DBPlugin):
         {
             'command': 'reload',
             'text': _('Reload'),
-            'icon': 'step-forward',
+            'icon': 'reload',
         }
     ]
 

--- a/ajenti/plugins/nginx/main.py
+++ b/ajenti/plugins/nginx/main.py
@@ -14,7 +14,7 @@ class Nginx(WebserverPlugin):
         {
             'command': 'force-reload',
             'text': _('Reload'),
-            'icon': 'step-forward',
+            'icon': 'reload',
         }
     ]
     hosts_available_dir = platform_select(

--- a/ajenti/plugins/psql/main.py
+++ b/ajenti/plugins/psql/main.py
@@ -11,7 +11,7 @@ class PSQLPlugin (DBPlugin):
         {
             'command': 'reload',
             'text': _('Reload'),
-            'icon': 'step-forward',
+            'icon': 'reload',
         }
     ]
 

--- a/ajenti/plugins/services/layout/bar.xml
+++ b/ajenti/plugins/services/layout/bar.xml
@@ -1,5 +1,5 @@
 <hc id="buttons">
     <button id="start" icon="play" text="{Start}" />
     <button id="stop" icon="stop" text="{Stop}" />
-    <button id="restart" icon="step-forward" text="{Restart}" />
+    <button id="restart" icon="restart" text="{Restart}" />
 </hc>

--- a/ajenti/plugins/services/layout/main.xml
+++ b/ajenti/plugins/services/layout/main.xml
@@ -23,7 +23,7 @@
                                 <button id="stop" icon="stop" style="mini" />
                             </tooltip>
                             <tooltip text="{Restart}">
-                                <button id="restart" icon="step-forward" style="mini" />
+                                <button id="restart" icon="restart" style="mini" />
                             </tooltip>
                         </hc>
                     </dtd>

--- a/ajenti/plugins/services/layout/widget.xml
+++ b/ajenti/plugins/services/layout/widget.xml
@@ -13,7 +13,7 @@
         <button id="stop" icon="stop" style="mini" visible="False" />
     </tooltip>
     <tooltip text="{Restart}">
-        <button id="restart" icon="step-forward" style="mini" visible="False" />
+        <button id="restart" icon="restart" style="mini" visible="False" />
     </tooltip>
     
     <dialog id="config-dialog" visible="False">

--- a/ajenti/plugins/supervisor/layout/main.xml
+++ b/ajenti/plugins/supervisor/layout/main.xml
@@ -6,7 +6,7 @@
             [{
                 'command': 'force-reload',
                 'text': _('Reload'),
-                'icon': 'step-forward',
+                'icon': 'reload',
             }]
         " />
 


### PR DESCRIPTION
#### What does this PR do?

Restart and reload icons were incorrect and they were misleading the user. Now they are correct and more proper for the commands themselves. 
#### Where should the reviewer start?

The best place to look is _Services_ page. 
#### How should this be manually tested?
- [ ] Start your instance
- [ ] Open Services page
- [ ] Check if you see the new (and proper) icons
#### Documents
##### Screenshots (if appropriate)

The change is at the right-most icon:
![Old icons](http://i.imgur.com/BCjXQBc.png)
![New icons](http://i.imgur.com/lZjq31e.png)

and these ones:
![Old icons](http://i.imgur.com/xU0fTyk.png)
![New icons](http://i.imgur.com/9JY7DiA.png)
##### Other documents

Nothing, sorry.
#### Who should be notified?

IDK. This is a visual change. 
#### What should happen on deployment? (check all that apply)
- [x] The usual steps.
- [ ] There are database changes, which should be run.
- [ ] There are files that should be manually uploaded.
#### Questions:
- Does this require a blog post?
  - Nope.
- Does this require a knowledge base update?
  - Nope.
- Does support need training for this?
  - Nope.
- Does this has to be communicated to partners?
  - Nope.
