### PR TITLE
Breaks compatibility with old gevent version #886

### DIFF
--- a/ajenti/compat.py
+++ b/ajenti/compat.py
@@ -117,7 +117,7 @@ def new_sslwrap(sock, server_side=False, keyfile=None, certfile=None, cert_reqs=
     caller_self = inspect.currentframe().f_back.f_locals['self']
     return context._wrap_socket(sock, server_side=server_side, ssl_sock=caller_self)
 
-if not hasattr(gevent.ssl, 'SSLContext'):
+if hasattr(__ssl__, 'SSLContext') and not hasattr(gevent.ssl, 'SSLContext'):
     _ssl.sslwrap = new_sslwrap
 
 


### PR DESCRIPTION
My previous PR #882 went to an undefined method on some environnement. I need to be even more careful later on. Sorry for that.

Tested on Debian 7 and 8, Centos 7 and #886 report that works on Ubuntu 14.04 LTS too.
