### PR TITLE
Can leed to undefined (really a micro detail)

### DIFF
--- a/ajenti/plugins/dashboard/updater.py
+++ b/ajenti/plugins/dashboard/updater.py
@@ -11,8 +11,8 @@ class AjentiUpdater (BasePlugin):
     def run_update(self, packages):
         packages = packages or [self.AJENTI_PACKAGE_NAME]
         actions = []
+        mgr = PackageManager.get()
         for name in packages:
-            mgr = PackageManager.get()
             p = PackageInfo()
             p.name, p.action = name, 'i'
             actions.append(p)


### PR DESCRIPTION
It's just a mini little thing I see along reading the ajenti's code.
As if packages is always defined, instead of redeclare at each loop, do only once :)
Not a big deal though.
