### PR TITLE
Fix wrong PT Sans Bold font link

### DIFF
--- a/ajenti/plugins/main/content/css/main.less
+++ b/ajenti/plugins/main/content/css/main.less
@@ -43,7 +43,7 @@
 
 @font-face {
 	font-family: 'PT Sans';
-	src: url('pt_sans-web-bold.eot');
+	src: url('main/fonts/pt_sans-web-bold.eot');
 	src: local('PT Sans Bold'), local('PTSans-Bold'), local('PT_Sans-Bold')
 		url('main/fonts/pt_sans-web-bold.eot?#iefix') format('embedded-opentype'),
 		url('main/fonts/pt_sans-web-bold.woff2') format('woff2'),


### PR DESCRIPTION
This fix a typo in this CSS

@Eugeny I don't know how you build packages for system's distribution like debian or redhat, but can you verify that less and coffee are well compiled on the packages ?

Because some users got olds fonts, that results of old CSS (and probably JS).
Please see #855 (and duplicates).

Thank you :)
