### PR TITLE
Missing dependency - 'wheel' (pip)

### DIFF
--- a/docs/source/man/install.rst
+++ b/docs/source/man/install.rst
@@ -45,7 +45,7 @@ Install Ajenti
 
 Upgrade PIP::
 
-    sudo pip install 'setuptools>=0.6rc11' 'pip>=6'
+    sudo pip install 'setuptools>=0.6rc11' 'pip>=6' wheel
 
 Minimal install::
 


### PR DESCRIPTION
Manual installation is failing because pip did not install wheel.