### PR TITLE
handle_api_time_sync - error

### DIFF
--- a/plugins/datetime/views.py
+++ b/plugins/datetime/views.py
@@ -59,7 +59,7 @@ class Handler(HttpPlugin):
             raise EndpointError(_('ntpdate utility is not installed'))
 
         try:
-            subprocess.check_call(['ntpdate', '0.pool.ntp.org'])
+            subprocess.check_call(['ntpdate', '-u', '0.pool.ntp.org'])
         except Exception as e:
             raise EndpointError(e)
         return int(time.time())


### PR DESCRIPTION
When ntp daemon is installed and running ntpdate invocation returns error.

Error:  ntpdate[12919]: the NTP socket is in use, exiting

Need to use ntpdate with -u switch to be on the safe side. In this case ntpdate uses unprivileged random port for outgoing packets.