### PR TITLE
DataTime Plugin - Time Error after Syncronization

### DIFF
--- a/plugins/datetime/views.py
+++ b/plugins/datetime/views.py
@@ -62,4 +62,4 @@ class Handler(HttpPlugin):
             subprocess.check_call(['ntpdate', '-u', '0.pool.ntp.org'])
         except Exception as e:
             raise EndpointError(e)
-        return int(time.time())
+        return int(time.time()-time.timezone)


### PR DESCRIPTION
time.time() return UTC - Ref: http://stackoverflow.com/questions/16554887/does-pythons-time-time-return-a-timestamp-in-utc

Consequently, DateTime time plugin displays UTC time after synchronization even when the timezone is set to another one. It can be misleading for users from other time zones. It gets corrected when they click on set time zone in DateTime plugin view but that is bad UX.

Hence returning appropriate localtime by adding tz offset.