### PR TITLE
Add needrestart plugin

### DIFF
--- a/ajenti/plugins/needrestart/__init__.py
+++ b/ajenti/plugins/needrestart/__init__.py
@@ -1,0 +1,19 @@
+from ajenti.api import *
+from ajenti.plugins import *
+
+
+info = PluginInfo(
+    title='needrestart',
+    description='Show pending service/container restart and system reboot',
+    icon='restart',
+    dependencies=[
+        PluginDependency('main'),
+        PluginDependency('dashboard'),
+        PluginDependency('power'),
+        BinaryDependency('needrestart'),
+    ],
+)
+
+
+def init():
+    import widget

--- a/ajenti/plugins/needrestart/layout/widget.xml
+++ b/ajenti/plugins/needrestart/layout/widget.xml
@@ -1,0 +1,17 @@
+<hc>
+    <box width="20">
+        <icon id="icon" icon="restart" />
+    </box>
+    <box width="90">
+        <label id="name" style="bold" text="---" />
+    </box>
+    <box width="200">
+        <label id="value" />
+    </box>
+    <tooltip id="reboottooltip" text="{Reboot}" visible="false">
+        <button style="mini" id="reboot" icon="undo" warning="{Reboot the system?}" />
+    </tooltip>
+    <tooltip id="needrestarttooltip" text="{Restart services/containers}" visible="false">
+        <button style="mini" id="restart" icon="restart" warning="{Restart services/containers?}" />
+    </tooltip>
+</hc>

--- a/ajenti/plugins/needrestart/widget.py
+++ b/ajenti/plugins/needrestart/widget.py
@@ -1,0 +1,67 @@
+import subprocess
+import logging
+
+from ajenti.api import plugin
+from ajenti.api.sensors import Sensor
+from ajenti.plugins.dashboard.api import DashboardWidget
+from ajenti.util import platform_select
+from ajenti.ui import on
+from ajenti.users import PermissionProvider, restrict
+
+from ajenti.plugins.power.api import PowerController
+
+@plugin
+class RebootRequired (Sensor):
+    id = 'needrestart'
+    timeout = 1
+
+    def measure(self, variant):
+        output = subprocess.check_output(['needrestart', '-b']).strip()
+        return output
+
+
+@plugin
+class RebootWidget (DashboardWidget):
+    name = _('Need Restart')
+    icon = 'restart'
+
+    def init(self):
+        self.sensor = Sensor.find('needrestart')
+        self.append(self.ui.inflate('needrestart:widget'))
+
+        self.find('icon').text = 'restart'
+        self.find('name').text = _('Need Restart')
+        restartRequired = True
+        if "NEEDRESTART-KSTA: 3" in self.sensor.value():
+            self.find('value').text = _('Reboot required')
+            self.find('reboottooltip').visible = True
+        elif "NEEDRESTART-KSTA: 1" in self.sensor.value() or "NEEDRESTART-KSTA: 2" in self.sensor.value():
+            if "NEEDRESTART-SVC:" in self.sensor.value():
+                self.find('value').text = _('Service restart required')
+                self.find('needrestarttooltip').visible = True
+            elif "NEEDRESTART-CONT:" in self.sensor.value():
+                self.find('value').text = _('Container restart required')
+                self.find('needrestarttooltip').visible = True
+            else:
+                self.find('value').text = _('no pending restart')
+                restartRequired = False
+        else:
+            self.find('value').text = 'unknown state, output:\n' + self.sensor.value()
+
+        if restartRequired:
+            self.find('icon').style = 'yellow'
+            self.find('icon').icon = 'warning-sign'
+        self.powerctl = PowerController.get()
+
+    @on('reboot', 'click')
+    @restrict('needrestart:reboot')
+    def on_reboot(self):
+        logging.info('[needrestart] reboot')
+        self.powerctl.reboot()
+
+    @on('restart', 'click')
+    @restrict('needrestart:restart')
+    def on_restart(self):
+        logging.info('[needrestart] restart services/containers')
+        output = subprocess.check_output(['needrestart', '-r', 'a']).strip()        
+        logging.info('[needrestart] '+output)

--- a/ajenti/plugins/packages/installer.py
+++ b/ajenti/plugins/packages/installer.py
@@ -60,6 +60,7 @@ db = {
         'nginx': 'nginx',
         'ipmitool': 'ipmitool',
         'rethinkdb': 'rethinkdb',
+        'needrestart': 'needrestart',
     },
     'centos': {
         'python-module-BeautifulSoup': 'python-BeautifulSoup',
@@ -127,5 +128,6 @@ db = {
         'named': 'bind',
         'ipmitool': 'ipmitool',
         'rethinkdb': 'rethinkdb',
+        'needrestart': 'needrestart',
     },
 }


### PR DESCRIPTION
Add plugin to show pending service/container restart and system reboot.

![needrestart](https://cloud.githubusercontent.com/assets/6691165/25116386/c4d65ff0-240c-11e7-8bf1-00f0781ebbd4.png)
 There is also a result "Container restart required" which I have not tested.
