### PR TITLE
Pypi switch to https for update checkout.

### DIFF
--- a/ajenti-panel/ajenti-upgrade
+++ b/ajenti-panel/ajenti-upgrade
@@ -21,7 +21,7 @@ if sys.stdout.isatty():
 pending = {}
 
 for package in installed:
-    data = requests.get('http://pypi.python.org/pypi/%s/json' % package).json()
+    data = requests.get('https://pypi.python.org/pypi/%s/json' % package).json()
     if sys.stdout.isatty():
         sys.stdout.write('.')
         sys.stdout.flush()

--- a/ajenti-panel/setup.py
+++ b/ajenti-panel/setup.py
@@ -58,6 +58,6 @@ setup(
     author_email='e@ajenti.org',
     url='http://ajenti.org/',
     packages=find_packages(),
-    scripts=['ajenti-panel', 'ajenti-ssl-gen', 'ajenti-client-ssl-gen'],
+    scripts=['ajenti-panel', 'ajenti-ssl-gen', 'ajenti-client-ssl-gen', 'ajenti-upgrade'],
     cmdclass={'install': install},
 )


### PR DESCRIPTION
Checkout by PyPi doesn't work anymore, ajenti-upgrade receives an empty json.