### PR TITLE
Convert filter object as list for PY3 compatibility.

### DIFF
--- a/ajenti-core/setup.py
+++ b/ajenti-core/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import platform
 import aj
 
-__requires = filter(None, open('requirements.txt').read().splitlines())
+__requires = list(filter(None, open('requirements.txt').read().splitlines()))
 if platform.python_implementation() == 'PyPy':
     __requires.append('git+git://github.com/schmir/gevent@pypy-hacks')
     __requires.append('git+git://github.com/gevent-on-pypy/pypycore ')


### PR DESCRIPTION
The function filter() has another behavior and creates a generator which has no append method.
pip3 install aj will fail because of it.
A simply solution would be to convert this generator as a list.