### PR TITLE
Username to lowercase during login

### DIFF
--- a/plugins/core/resources/js/core/controllers/login.controller.es
+++ b/plugins/core/resources/js/core/controllers/login.controller.es
@@ -15,6 +15,7 @@ angular.module('core').controller('CoreLoginController', function($scope, $log, 
             return;
         }
         $scope.working = true;
+        $scope.username = $scope.username.toLowerCase();
         identity.auth($scope.username, $scope.password, $scope.mode).then(username => {
             $scope.success = true;
             location.href = $routeParams.nextPage || '/';


### PR DESCRIPTION
Another minor fix:
Transform the username to lowercase during login.

Login names in unix are in general lowercase, however ajenti accepts
the login in Uppercase or mixed case as well. Unfortunately
ajenti permissions are case sensitive so it makes sense to bring them all
to the same.
