### PR TITLE
Link compatibility with ng-flow.

### DIFF
--- a/plugins/filemanager/resources/partial/index.html
+++ b/plugins/filemanager/resources/partial/index.html
@@ -45,7 +45,7 @@
         <a ng:click="showNewFileDialog()" class="btn btn-default btn-flat" test-bind="newFileButton" translate>New file</a>
         <a ng:click="showNewDirectoryDialog()" class="btn btn-default btn-flat" test-bind="newDirectoryButton" translate>New directory</a>
 
-        <a flow-btn class="btn btn-default btn-flat" test-bind="uploadButton" translate>Upload</a>
+        <span flow-btn class="btn btn-default btn-flat" test-bind="uploadButton" translate>Upload</span>
 
         <a ng:click="doPaste()" ng:show="clipboard.length > 0" class="btn btn-default btn-flat" test-bind="pasteButton" translate>Paste here</a>
 


### PR DESCRIPTION
The upload button doesn't work anymore in filemanager, maybe it's possible to pin the ng-flow version, or simply change the link as a span tag, like this pull request.

More information here : https://www.npmjs.com/package/@flowjs/ng-flow/v/2.7.7

"Note: avoid using <a> and <button> tags as file upload buttons, use <span> instead."