### PR TITLE
Basically tests if certificate is valid.

### DIFF
--- a/plugins/settings/resources/js/controllers/index.controller.es
+++ b/plugins/settings/resources/js/controllers/index.controller.es
@@ -55,7 +55,6 @@ angular.module('ajenti.settings').controller('SettingsIndexController', ($scope,
 
     $scope.save = () => {
         $scope.certificate = config.data.ssl.certificate;
-        console.log('bla');
         if ($scope.certificate != $scope.oldCertificate) {
             return  $http.post('/api/settings/test-certificate/', {'certificate': $scope.certificate})
                     .then(data => { config.save().then(dt => notify.success(gettext('Saved')))})

--- a/plugins/settings/resources/js/controllers/index.controller.es
+++ b/plugins/settings/resources/js/controllers/index.controller.es
@@ -2,6 +2,7 @@ angular.module('ajenti.settings').controller('SettingsIndexController', ($scope,
     pageTitle.set(gettext('Settings'));
 
     $scope.config = config;
+    $scope.oldCertificate = config.data.ssl.certificate;
 
     $scope.availableColors = [
         'default',
@@ -52,12 +53,15 @@ angular.module('ajenti.settings').controller('SettingsIndexController', ($scope,
         }
     });
 
-    $scope.save = () =>
-        config.save().then(data =>
-            notify.success(gettext('Saved'))
-        ).catch(() =>
-            notify.error(gettext('Could not save config'))
-        );
+    $scope.save = () => {
+        $scope.certificate = config.data.ssl.certificate;
+        console.log('bla');
+        if ($scope.certificate != $scope.oldCertificate) {
+            return  $http.post('/api/settings/test-certificate/', {'certificate': $scope.certificate})
+                    .then(data => { config.save().then(dt => notify.success(gettext('Saved')))})
+                    .catch(err => { notify.error(gettext('SSL Error')), err.message});
+        };
+    };
 
     $scope.createNewServerCertificate = () =>
         messagebox.show({

--- a/plugins/settings/views.py
+++ b/plugins/settings/views.py
@@ -74,3 +74,17 @@ class Handler(HttpPlugin):
         return {
             'path': certificate_path,
         }
+
+    @url(r'/api/settings/test-certificate/')
+    @endpoint(api=True)
+    def handle_test_certificate(self, http_context):
+        if http_context.method == 'POST':
+            data = http_context.json_body()
+            certificate_path = data['certificate']
+            try:
+                certificate = load_certificate(FILETYPE_PEM, open(certificate_path).read())
+                private_key = load_privatekey(FILETYPE_PEM, open(certificate_path).read())
+            except Exception as e:
+                raise EndpointError(None, message=str(e))    
+                
+            return {'path': certificate_path}


### PR DESCRIPTION
Save action tests with OpenSSL if the certificate is ok.

Only throw the python load error if the certificate is not valid, not very user friendly, but it may helps to debug.