### PR TITLE
Configpost

### DIFF
--- a/plugins/auth_users/resources/js/controllers/index.controller.es
+++ b/plugins/auth_users/resources/js/controllers/index.controller.es
@@ -15,7 +15,7 @@ angular.module('ajenti.auth.users').controller('AuthUsersIndexController', funct
             };
         }
         config.getPermissions(config).then((data) => {
-            $scope.permissions = data;console.log(data);
+            $scope.permissions = data;
             let result = [];
             for (let username in config.data.auth.users) {
                 $scope.resetPermissions(username);

--- a/plugins/auth_users/resources/js/controllers/index.controller.es
+++ b/plugins/auth_users/resources/js/controllers/index.controller.es
@@ -14,8 +14,8 @@ angular.module('ajenti.auth.users').controller('AuthUsersIndexController', funct
                 }
             };
         }
-        config.getPermissions().then((data) => {
-            $scope.permissions = data;
+        config.getPermissions(config).then((data) => {
+            $scope.permissions = data;console.log(data);
             let result = [];
             for (let username in config.data.auth.users) {
                 $scope.resetPermissions(username);

--- a/plugins/datetime/main.py
+++ b/plugins/datetime/main.py
@@ -14,7 +14,7 @@ class ItemProvider(SidebarItemProvider):
             {
                 'attach': 'category:system',
                 'id': 'datetime',
-                'name': _('Date &amp; time'),
+                'name': _('Date & time'),
                 'icon': 'clock-o',
                 'url': '/view/datetime',
                 'children': [],

--- a/plugins/settings/resources/js/controllers/index.controller.es
+++ b/plugins/settings/resources/js/controllers/index.controller.es
@@ -34,7 +34,7 @@ angular.module('ajenti.settings').controller('SettingsIndexController', ($scope,
     });
 
     config.load().then(
-        () => config.getAuthenticationProviders(), () => notify.error(gettext('Could not load config'))
+        () => config.getAuthenticationProviders(config), () => notify.error(gettext('Could not load config'))
     ).then(p =>
         $scope.authenticationProviders = p
     ).catch(() =>


### PR DESCRIPTION
I don't reealy know why it is a problem with PY3 ( plugins auth-users and settings get a 500 ) and not for PY2, but the methods .getAuthenticationProviders() and .getPermissions() in [config.service.es](https://github.com/ajenti/ajenti/blob/master/plugins/core/resources/js/core/services/config.service.es) send the config as post request, and there was no parameter in the controllers from the plugins auth-users and settings. 