### PR TITLE
Output from systemd list must be json serializable.

### DIFF
--- a/plugins/services/managers/systemd_manager.py
+++ b/plugins/services/managers/systemd_manager.py
@@ -18,32 +18,32 @@ class SystemdServiceManager(ServiceManager):
 
     def list(self, units=None):
         if not units:
-            units = [x.split()[0] for x in subprocess.check_output(['systemctl', 'list-unit-files', '--no-legend', '--no-pager', '-la']).splitlines() if x]
-            units = [x for x in units if x.endswith(b'.service') and b'@' not in x]
+            units = [x.split()[0] for x in subprocess.check_output(['systemctl', 'list-unit-files', '--no-legend', '--no-pager', '-la']).decode().splitlines() if x]
+            units = [x for x in units if x.endswith('.service') and '@' not in x]
             units = list(set(units))
 
         cmd = ['systemctl', 'show', '-o', 'json', '--full', '--all'] + units
 
         used_names = set()
         unit = {}
-        for l in subprocess.check_output(cmd).splitlines() + [None]:
+        for l in subprocess.check_output(cmd).decode().splitlines() + [None]:
             if not l:
                 if len(unit) > 0:
                     svc = Service(self)
-                    svc.id = unit[b'Id']
-                    svc.name, type = svc.id.rsplit(b'.', 1)
+                    svc.id = unit['Id']
+                    svc.name, type = svc.id.rsplit('.', 1)
 
-                    svc.name = svc.name.replace(b'\\x2d', b'\x2d')
-                    svc.running = unit[b'SubState'] == b'running'
-                    svc.state = b'running' if svc.running else b'stopped'
+                    svc.name = svc.name.replace('\\x2d', '\x2d')
+                    svc.running = unit['SubState'] == 'running'
+                    svc.state = 'running' if svc.running else 'stopped'
 
                     if svc.name not in used_names:
                         yield svc
 
                     used_names.add(svc.name)
                 unit = {}
-            elif b'=' in l:
-                k, v = l.split(b'=', 1)
+            elif '=' in l:
+                k, v = l.split('=', 1)
                 unit[k] = v
 
     def get_service(self, _id):


### PR DESCRIPTION
I made an error last month with this [commit](https://github.com/ajenti/ajenti/commit/4d6078e0ba1aac3fd091ca3d9d0f1bfecc744f66#diff-af1ed1d1f1da8d3c0fe59fb549755848) : listing sysv processes was running, but I didn't see that it was not possible to list systemd processes anymore, and the reason is simply that the returned dict must be json serializable.