### PR TITLE
Force TLSv1.2

### DIFF
--- a/ajenti-core/aj/core.py
+++ b/ajenti-core/aj/core.py
@@ -148,12 +148,9 @@ def run(config=None, plugin_providers=None, product_name='ajenti', dev_mode=Fals
     )
 
     if aj.config.data['ssl']['enable'] and aj.config.data['bind']['mode'] == 'tcp':
-        try:
-            context = SSL.Context(SSL.TLSv1_2_METHOD)
-        except:
-            context = SSL.Context(SSL.TLSv1_METHOD)
+        context = SSL.Context(SSL.TLSv1_2_METHOD)
         context.set_session_id(str(id(context)))
-        context.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3)
+        context.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3 | SSL.OP_NO_TLSv1 | SSL.OP_NO_TLSv1_1)
         context.set_cipher_list('ALL:!ADH:!EXP:!LOW:!RC2:!3DES:!SEED:!RC4:+HIGH:+MEDIUM')
 
         certificate = crypto.load_certificate(


### PR DESCRIPTION
I think all systems can now use TLS v1.2 without errors.