### PR TITLE
Sessions

### DIFF
--- a/ajenti-core/aj/config.py
+++ b/ajenti-core/aj/config.py
@@ -33,6 +33,7 @@ class BaseConfig(object):
     def ensure_structure(self):
         self.data.setdefault('name', None)
         self.data.setdefault('max_sessions', 99)
+        self.data.setdefault('session_max_time', 3600)
         self.data.setdefault('language', 'en')
         self.data.setdefault('restricted_user', 'nobody')
         self.data.setdefault('auth', {})

--- a/ajenti-core/aj/gate/middleware.py
+++ b/ajenti-core/aj/gate/middleware.py
@@ -136,7 +136,8 @@ class GateMiddleware(object):
             'address': env.get('REMOTE_ADDR', None),
         }
         session_key = self.generate_session_key(env)
-        session = Session(session_key, gateway_middleware=self, client_info=client_info, **kwargs)
+        session_max_time = aj.config.data['session_max_time']
+        session = Session(session_key, gateway_middleware=self, client_info=client_info, session_max_time=session_max_time, **kwargs)
         self.sessions[session_key] = session
         return session
 

--- a/ajenti-core/aj/gate/session.py
+++ b/ajenti-core/aj/gate/session.py
@@ -12,7 +12,7 @@ class Session(object):
 
     last_id = 0
 
-    def __init__(self, key, gateway_middleware=None, client_info=None, auth_info=None, **kwargs):
+    def __init__(self, key, gateway_middleware=None, client_info=None, auth_info=None, session_max_time=3600, **kwargs):
         Session.last_id += 1
         self.id = Session.last_id
         self.key = key
@@ -30,6 +30,7 @@ class Session(object):
         self.gate = WorkerGate(
             self, gateway_middleware=gateway_middleware, name='session %i' % self.id, log_tag='worker', **kwargs
         )
+        self.session_max_time = session_max_time
         self.gate.start()
         logging.debug('New session %s', self.id)
 
@@ -53,7 +54,7 @@ class Session(object):
         return time.time() - self.timestamp
 
     def is_dead(self):
-        return not self.active or self.get_age() > 3600
+        return not self.active or self.get_age() > self.session_max_time
 
     def set_cookie(self, http_context):
         """

--- a/ajenti-panel/config.yml
+++ b/ajenti-panel/config.yml
@@ -13,6 +13,7 @@ bind:
 color: bluegrey
 language: ru
 max_sessions: 9
+session_max_time: 3600
 name: Test Box
 restricted_user: nobody
 ssl:

--- a/ajenti-panel/setup.py
+++ b/ajenti-panel/setup.py
@@ -27,6 +27,7 @@ bind:
   port: 8000
 color: default
 max_sessions: 9
+session_max_time: 3600
 name: %s
 ssl:
   certificate:

--- a/plugins/core/content/pages/index.html
+++ b/plugins/core/content/pages/index.html
@@ -98,7 +98,7 @@
                 <p class="navbar-text pull-right hide-phone" style="min-width:99px;">
                     <i class="fa fa-hdd-o"></i> {{ identity.machine.name }}
                 </p>
-                <span translate class="pull-right sessiontime hide-phone">Session time : {{ counter[0] }}:{{ counter[1] }}:{{ counter[2] }}</span>
+                <span ng:if="identity.user" translate class="pull-right sessiontime hide-phone">Session time : {{ counter[0] }}:{{ counter[1] }}:{{ counter[2] }}</span>
             </div>
         </nav>
 

--- a/plugins/core/content/pages/index.html
+++ b/plugins/core/content/pages/index.html
@@ -95,9 +95,10 @@
                     </div>
                 </div>
 
-                <p class="navbar-text pull-right hide-phone">
+                <p class="navbar-text pull-right hide-phone" style="min-width:99px;">
                     <i class="fa fa-hdd-o"></i> {{ identity.machine.name }}
                 </p>
+                <span translate class="pull-right sessiontime hide-phone">Session time : {{ counter[0] }}:{{ counter[1] }}:{{ counter[2] }}</span>
             </div>
         </nav>
 

--- a/plugins/core/content/pages/index.html
+++ b/plugins/core/content/pages/index.html
@@ -98,7 +98,7 @@
                 <p class="navbar-text pull-right hide-phone" style="min-width:99px;">
                     <i class="fa fa-hdd-o"></i> {{ identity.machine.name }}
                 </p>
-                <span ng:if="identity.user" translate class="pull-right sessiontime hide-phone">Session time : {{ counter[0] }}:{{ counter[1] }}:{{ counter[2] }}</span>
+                <span ng:if="identity.user && resttime < 1800" translate class="pull-right sessiontime hide-phone">Session time : {{ counter[0] }}:{{ counter[1] }}:{{ counter[2] }}</span>
             </div>
         </nav>
 

--- a/plugins/core/resources/css/app.less
+++ b/plugins/core/resources/css/app.less
@@ -382,5 +382,5 @@ progress-spinner {
 .sessiontime {
     font-size:10px;
     margin-right:-134px;
-    margin-top:45px;
+    margin-top:40px;
 }

--- a/plugins/core/resources/css/app.less
+++ b/plugins/core/resources/css/app.less
@@ -378,3 +378,9 @@ progress-spinner {
 .sv-helper {
     position: fixed;
 }
+
+.sessiontime {
+    font-size:10px;
+    margin-right:-134px;
+    margin-top:45px;
+}

--- a/plugins/core/resources/js/core/controllers/root.controller.es
+++ b/plugins/core/resources/js/core/controllers/root.controller.es
@@ -1,4 +1,4 @@
-angular.module('core').controller('CoreRootController', function($scope, $rootScope, $location, $localStorage, $log, $timeout, $q, identity, customization, urlPrefix, ajentiPlugins, ajentiVersion, ajentiPlatform, ajentiPlatformUnmapped, favicon, feedback, locale, config) {
+angular.module('core').controller('CoreRootController', function($scope, $rootScope, $location, $localStorage, $log, $timeout, $q, $interval, $http, identity, customization, urlPrefix, ajentiPlugins, ajentiVersion, ajentiPlatform, ajentiPlatformUnmapped, favicon, feedback, locale, config) {
     $rootScope.identity = identity;
     $rootScope.$location = $location;
     $rootScope.location = location;
@@ -82,4 +82,24 @@ angular.module('core').controller('CoreRootController', function($scope, $rootSc
             $scope.$apply(() => $rootScope.$broadcast('window:resize'))
         })
     );
+
+    $http.get('/api/core/session-time').then((resp) => {
+        $scope.resttime = resp.data;
+        $rootScope.counter = $scope.convertTime($scope.resttime);
+    });
+
+    $scope.countDown = function() {
+        $scope.resttime -= 1;
+        $rootScope.counter = $scope.convertTime($scope.resttime);
+    };
+
+    $scope.convertTime = function(seconds) {
+        hours = ('00' + Math.floor(seconds/3600)).slice(-2);
+        rest = seconds % 3600;
+        minutes = ('00' + Math.floor(rest/60)).slice(-2);
+        seconds = ('00' + rest % 60).slice(-2);
+        return [hours, minutes, seconds]
+    };
+
+    $interval($scope.countDown, 1000, 0);
 });

--- a/plugins/core/resources/js/core/controllers/root.controller.es
+++ b/plugins/core/resources/js/core/controllers/root.controller.es
@@ -84,13 +84,13 @@ angular.module('core').controller('CoreRootController', function($scope, $rootSc
     );
 
     $http.get('/api/core/session-time').then((resp) => {
-        $scope.resttime = resp.data;
-        $rootScope.counter = $scope.convertTime($scope.resttime);
+        $rootScope.resttime = resp.data;
+        $rootScope.counter = $scope.convertTime($rootScope.resttime);
     });
 
     $scope.countDown = function() {
-        $scope.resttime -= 1;
-        $rootScope.counter = $scope.convertTime($scope.resttime);
+        $rootScope.resttime -= 1;
+        $rootScope.counter = $scope.convertTime($rootScope.resttime);
     };
 
     $scope.convertTime = function(seconds) {

--- a/plugins/core/views/api.py
+++ b/plugins/core/views/api.py
@@ -148,4 +148,5 @@ class Handler(HttpPlugin):
     @url('/api/core/session-time')
     @endpoint(api=True)
     def handle_api_sessiontime(self, http_context):
-        return int(self.context.session.timestamp+3600-time())
+        session_max_time = aj.config.data['session_max_time'] if aj.config.data['session_max_time'] else 3600
+        return int(self.context.session.timestamp + session_max_time - time())

--- a/plugins/core/views/api.py
+++ b/plugins/core/views/api.py
@@ -4,6 +4,8 @@ import os
 import socket
 import traceback
 from jadi import component
+from datetime import timedelta
+from time import time
 
 import aj
 from aj.api.http import url, HttpPlugin
@@ -142,3 +144,8 @@ class Handler(HttpPlugin):
                         languages.add(lang)
 
         return sorted(list(languages))
+
+    @url('/api/core/session-time')
+    @endpoint(api=True)
+    def handle_api_sessiontime(self, http_context):
+        return int(self.context.session.timestamp+3600-time())


### PR DESCRIPTION
First commit : possibility to configure max session duration, default to 3600s.
Since there's a conflict with importing `aj` in `session.py` ( conflict between `aj.config` the module and `aj.config` the property ), I pass the parameter in the Session constructor in `middleware.py`.

Second commit : show remaining time for the current session. Not very proud of the css, but it's always aligned with the hostname, even if the hostname is shorter ( tested with Chrome and firefox with many differents resolutions ).

![2019-10-02_22-20](https://user-images.githubusercontent.com/10401079/66079366-33334880-e564-11e9-87a8-95abf4d2a789.png)

