### PR TITLE
Sslsocket

### DIFF
--- a/ajenti-core/aj/config.py
+++ b/ajenti-core/aj/config.py
@@ -33,6 +33,7 @@ class BaseConfig(object):
     def ensure_structure(self):
         self.data.setdefault('name', None)
         self.data.setdefault('max_sessions', 99)
+        self.data.setdefault('session_max_time', 3600)
         self.data.setdefault('language', 'en')
         self.data.setdefault('restricted_user', 'nobody')
         self.data.setdefault('auth', {})
@@ -41,6 +42,7 @@ class BaseConfig(object):
         self.data.setdefault('ssl', {})
         self.data['ssl'].setdefault('enable', False)
         self.data['ssl'].setdefault('certificate', None)
+        self.data['ssl'].setdefault('fqdn_certificate', None)
         self.data['ssl'].setdefault('client_auth', {})
         self.data['ssl']['client_auth'].setdefault('enable', False)
         self.data['ssl']['client_auth'].setdefault('force', False)

--- a/ajenti-core/aj/core.py
+++ b/ajenti-core/aj/core.py
@@ -20,6 +20,7 @@ from aj.plugins import PluginManager
 from aj.wsgi import RequestHandler
 
 import gevent
+import ssl
 import gevent.ssl
 from gevent import monkey
 
@@ -147,11 +148,30 @@ def run(config=None, plugin_providers=None, product_name='ajenti', dev_mode=Fals
 
     if aj.config.data['ssl']['enable'] and aj.config.data['bind']['mode'] == 'tcp':
         aj.server.ssl_args = {'server_side': True}
-        certificate = aj.config.data['ssl']['certificate']
+        cert_path = aj.config.data['ssl']['certificate']
+
+        if aj.config.data['ssl']['client_auth']['enable']:
+            context = gevent.ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.load_cert_chain(certfile=cert_path, keyfile=cert_path)
+            context.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+            context.set_ciphers('ALL:!ADH:!EXP:!LOW:!RC2:!3DES:!SEED:!RC4:+HIGH:+MEDIUM')
+
+            #context.load_verify_locations(cafile=cert_path)
+            #context.verify_mode = ssl.CERT_OPTIONAL
+            # todo harden files
+            # logging.info('Enabling SSL client authentication')
+            # context.add_client_ca(certificate)
+            # context.get_cert_store().add_cert(certificate)
+            # verify_flags = SSL.VERIFY_PEER
+            # if aj.config.data['ssl']['client_auth']['force']:
+                # context.verify_mode = ssl.CERT_REQUIRED
+                # verify_flags |= SSL.VERIFY_FAIL_IF_NO_PEER_CERT
+            # context.set_verify(verify_flags, AuthenticationService.get(aj.context).client_certificate_callback)
+            # context.set_verify_depth(0)
 
         # Temporary wrapper to test SSLSocket from gevent
         def wp(socket, **args):
-            return gevent.ssl.SSLSocket(sock=socket, certfile=certificate, keyfile=certificate, server_side=True)
+            return context.wrap_socket(sock=socket, server_side=True)
 
         aj.server.wrap_socket = wp
         logging.info('SSL enabled')

--- a/ajenti-core/aj/core.py
+++ b/ajenti-core/aj/core.py
@@ -149,7 +149,7 @@ def run(config=None, plugin_providers=None, product_name='ajenti', dev_mode=Fals
     if aj.config.data['ssl']['enable'] and aj.config.data['bind']['mode'] == 'tcp':
         aj.server.ssl_args = {'server_side': True}
         cert_path = aj.config.data['ssl']['certificate']
-        if 'fqdn_certificate' in aj.config.data['ssl'].keys():
+        if aj.config.data['ssl']['fqdn_certificate']:
             fqdn_cert_path = aj.config.data['ssl']['fqdn_certificate']
         else:
             fqdn_cert_path = cert_path

--- a/ajenti-core/aj/core.py
+++ b/ajenti-core/aj/core.py
@@ -168,10 +168,7 @@ def run(config=None, plugin_providers=None, product_name='ajenti', dev_mode=Fals
             else:
                 context.verify_mode = ssl.CERT_OPTIONAL
 
-            ## Depth 0 ?
-            # context.verify_flags = ssl.VERIFY_CRL_CHECK_LEAF
-
-            ## Test callback ( this must return None to get forward )
+            ## Test callback : client_certificate_callback must return None to get forward
             # context.set_servername_callback(AuthenticationService.get(aj.context).client_certificate_callback)
 
         aj.server.wrap_socket = lambda socket, **args:context.wrap_socket(sock=socket, server_side=True)

--- a/ajenti-core/aj/security/verifier.py
+++ b/ajenti-core/aj/security/verifier.py
@@ -13,5 +13,5 @@ class ClientCertificateVerificator(object):
         digest = x509.digest('sha1')
         # logging.debug('SSL verify: %s / %s' % (x509.get_subject(), digest))
         for c in aj.config.data['ssl']['client_auth']['certificates']:
-            if c['serial'] == serial and c['digest'] == digest:
+            if long(c['serial']) == serial and c['digest'] == digest:
                 return c['user']

--- a/ajenti-core/aj/security/verifier.py
+++ b/ajenti-core/aj/security/verifier.py
@@ -1,7 +1,9 @@
 from jadi import service
-
+from six import PY3
 import aj
 
+if PY3:
+    long = int
 
 @service
 class ClientCertificateVerificator(object):

--- a/ajenti-core/aj/wsgi.py
+++ b/ajenti-core/aj/wsgi.py
@@ -1,7 +1,7 @@
 from socketio.handler import SocketIOHandler
 import six
 import aj
-from aj.util.sslsocket import SSLSocket
+from gevent._ssl3 import SSLSocket # Only PY3 compatible
 from aj.security.verifier import ClientCertificateVerificator
 
 
@@ -15,14 +15,14 @@ class RequestHandler(SocketIOHandler):
         env['SSL'] = isinstance(self.socket, SSLSocket)
         env['SSL_CLIENT_VALID'] = False
         env['SSL_CLIENT_USER'] = None
-        if env['SSL']:
-            certificate = self.socket.get_peer_certificate()
-            env['SSL_CLIENT_CERTIFICATE'] = certificate
-            if certificate:
-                user = ClientCertificateVerificator.get(aj.context).verify(certificate)
-                env['SSL_CLIENT_VALID'] = bool(user)
-                env['SSL_CLIENT_USER'] = user
-                env['SSL_CLIENT_DIGEST'] = certificate.digest('sha1')
+        # if env['SSL']:
+            # certificate = self.socket.get_peer_certificate()
+            # env['SSL_CLIENT_CERTIFICATE'] = certificate
+            # if certificate:
+                # user = ClientCertificateVerificator.get(aj.context).verify(certificate)
+                # env['SSL_CLIENT_VALID'] = bool(user)
+                # env['SSL_CLIENT_USER'] = user
+                # env['SSL_CLIENT_DIGEST'] = certificate.digest('sha1')
         return env
 
     def handle_one_response(self):
@@ -34,5 +34,5 @@ class RequestHandler(SocketIOHandler):
 
     def _sendall(self, data):
         if isinstance(data, six.text_type):
-                data = six.binary_type(data)
+                data = six.binary_type(data.encode('utf-8'))
         return SocketIOHandler._sendall(self, data)

--- a/ajenti-core/aj/wsgi.py
+++ b/ajenti-core/aj/wsgi.py
@@ -1,7 +1,7 @@
 from socketio.handler import SocketIOHandler
 import six
 import aj
-from gevent._ssl3 import SSLSocket # Only PY3 compatible
+from gevent.ssl import SSLSocket
 from aj.security.verifier import ClientCertificateVerificator
 
 

--- a/ajenti-core/aj/wsgi.py
+++ b/ajenti-core/aj/wsgi.py
@@ -1,9 +1,9 @@
 from socketio.handler import SocketIOHandler
 import six
 import aj
-from gevent.ssl import SSLSocket
+import gevent.ssl
 from aj.security.verifier import ClientCertificateVerificator
-
+from OpenSSL import crypto
 
 class RequestHandler(SocketIOHandler):
     def __init__(self, *args, **kwargs):
@@ -12,11 +12,11 @@ class RequestHandler(SocketIOHandler):
 
     def get_environ(self):
         env = SocketIOHandler.get_environ(self)
-        env['SSL'] = isinstance(self.socket, SSLSocket)
+        env['SSL'] = isinstance(self.socket, gevent.ssl.SSLSocket)
         env['SSL_CLIENT_VALID'] = False
         env['SSL_CLIENT_USER'] = None
         # if env['SSL']:
-            # certificate = self.socket.get_peer_certificate()
+            # certificate = crypto.load_certificate(crypto.FILETYPE_PEM, gevent.ssl.DER_cert_to_PEM_cert(self.socket.getpeercert(True)))
             # env['SSL_CLIENT_CERTIFICATE'] = certificate
             # if certificate:
                 # user = ClientCertificateVerificator.get(aj.context).verify(certificate)

--- a/ajenti-core/aj/wsgi.py
+++ b/ajenti-core/aj/wsgi.py
@@ -15,14 +15,16 @@ class RequestHandler(SocketIOHandler):
         env['SSL'] = isinstance(self.socket, gevent.ssl.SSLSocket)
         env['SSL_CLIENT_VALID'] = False
         env['SSL_CLIENT_USER'] = None
-        # if env['SSL']:
-            # certificate = crypto.load_certificate(crypto.FILETYPE_PEM, gevent.ssl.DER_cert_to_PEM_cert(self.socket.getpeercert(True)))
-            # env['SSL_CLIENT_CERTIFICATE'] = certificate
-            # if certificate:
-                # user = ClientCertificateVerificator.get(aj.context).verify(certificate)
-                # env['SSL_CLIENT_VALID'] = bool(user)
-                # env['SSL_CLIENT_USER'] = user
-                # env['SSL_CLIENT_DIGEST'] = certificate.digest('sha1')
+        if env['SSL']:
+            peer_cert = self.socket.getpeercert(True)
+            if peer_cert:
+                certificate = crypto.load_certificate(crypto.FILETYPE_PEM, gevent.ssl.DER_cert_to_PEM_cert(peer_cert))
+                env['SSL_CLIENT_CERTIFICATE'] = certificate
+                if certificate:
+                    user = ClientCertificateVerificator.get(aj.context).verify(certificate)
+                    env['SSL_CLIENT_VALID'] = bool(user)
+                    env['SSL_CLIENT_USER'] = user
+                    env['SSL_CLIENT_DIGEST'] = certificate.digest('sha1')
         return env
 
     def handle_one_response(self):

--- a/ajenti-core/requirements.txt
+++ b/ajenti-core/requirements.txt
@@ -1,7 +1,7 @@
 # core
 cookies
 gevent>=1.1.2
-gevent-socketio-master>=0.3.6.99
+gevent-socketio-hartwork>=0.3.6
 gevent-websocket
 gipc
 jadi>=1.0.3

--- a/ajenti-panel/config.yml
+++ b/ajenti-panel/config.yml
@@ -13,10 +13,12 @@ bind:
 color: bluegrey
 language: ru
 max_sessions: 9
+session_max_time: 3600
 name: Test Box
 restricted_user: nobody
 ssl:
   certificate: /etc/ajenti/ajenti.pem
+  fqdn_certificate: ''
   client_auth:
     certificates:
     - digest: 5F:C9:F2:8E:25:AC:D2:72:1B:B1:44:08:53:A7:11:9C:01:6C:D8:02

--- a/ajenti-panel/setup.py
+++ b/ajenti-panel/setup.py
@@ -27,9 +27,11 @@ bind:
   port: 8000
 color: default
 max_sessions: 9
+session_max_time: 3600
 name: %s
 ssl:
   certificate:
+  fqdn_certificate:
   client_auth:
     certificates: []
     enable: false

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,7 @@ class Mock(object):
 MOCK_MODULES = [
     'augeas',
     'gevent',
-    'gevent-socketio',
+    'gevent-socketio-hartwork',
     'gevent.event',
     'gevent.lock',
     'gevent.pywsgi',

--- a/plugins/settings/resources/js/controllers/index.controller.es
+++ b/plugins/settings/resources/js/controllers/index.controller.es
@@ -1,7 +1,7 @@
 angular.module('ajenti.settings').controller('SettingsIndexController', ($scope, $http, $sce, notify, pageTitle, identity, messagebox, passwd, config, core, locale, gettext) => {
     pageTitle.set(gettext('Settings'));
 
-    $scope.config = config;
+    $scope.config = config;console.log($scope.config);
     $scope.oldCertificate = config.data.ssl.certificate;
 
     $scope.availableColors = [

--- a/plugins/settings/resources/js/controllers/index.controller.es
+++ b/plugins/settings/resources/js/controllers/index.controller.es
@@ -1,7 +1,7 @@
 angular.module('ajenti.settings').controller('SettingsIndexController', ($scope, $http, $sce, notify, pageTitle, identity, messagebox, passwd, config, core, locale, gettext) => {
     pageTitle.set(gettext('Settings'));
 
-    $scope.config = config;console.log($scope.config);
+    $scope.config = config;
     $scope.oldCertificate = config.data.ssl.certificate;
 
     $scope.availableColors = [

--- a/plugins/settings/resources/partial/index.html
+++ b/plugins/settings/resources/partial/index.html
@@ -99,6 +99,14 @@
                         </a>
                     </div>
                 </div>
+                <label translate>SSL FQDN certificate file</label>
+                <div class="row">
+                    <div class="col-md-8">
+                        <path-selector ng:model="config.data.ssl.fqdn_certificate" type="text"></path-selector>
+                    </div>
+                    <div class="col-md-4">
+                    </div>
+                </div>
             </div>
 
             <hr/>

--- a/plugins/settings/views.py
+++ b/plugins/settings/views.py
@@ -44,7 +44,7 @@ class Handler(HttpPlugin):
         return {
             'digest': cert.digest('sha1'),
             'name': ','.join('%s=%s' % x for x in cert.get_subject().get_components()),
-            'serial': cert.get_serial_number(),
+            'serial': str(cert.get_serial_number()),
             'b64certificate': pkcs.export().encode('base64'),
         }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,7 +64,7 @@ echo ":: Upgrading PIP"
 rm /usr/lib/python2.7/dist-packages/setuptools.egg-info || true # for debian 7
 easy_install -U pip
 pip install -U pip wheel setuptools distribute
-pip uninstall -y gevent-socketio
+pip uninstall -y gevent-socketio gevent-socketio-hartwork
 
 echo ":: Installing Ajenti"
 `which pip` install ajenti-panel ajenti.plugin.dashboard ajenti.plugin.settings ajenti.plugin.plugins ajenti.plugin.notepad ajenti.plugin.terminal ajenti.plugin.filemanager ajenti.plugin.packages ajenti.plugin.services || exit 1


### PR DESCRIPTION
Hello,

I'm opening this PR, even if it's not complete, because it's easier to plan the final steps if the code is viewable.

There's many changes :

- use gevent.ssl instead of [aj/util/sslsocket.py](https://github.com/ajenti/ajenti/blob/master/ajenti-core/aj/util/sslsocket.py) for compatibility with Python3,
- use [gevent-socketio-hartwork](https://github.com/hartwork/gevent-socketio) which provides Python3 compatibility above gevent-socketio
- fix client auth bug with serial in `/etc/ajenti/config.yml`
- add new `fqdn_certificate` option to differenciate from self signed certificate as CA cert ( because, by example, it's not possible to use a Let's Encrypt certificate to generate a client certificate ).

I have tested this code under many situations, I hope I didn't forgot something ..., these situations are all possible combinations of : 

- Python2 or Python3,
- Webbrowser Chrome or Firefox,
- SSLContext CERT_NONE ( no client auth ) : trying to reach Ajenti with or without client certificate,
- SSLContext CERT_OPTIONAL ( client auth optional ) : trying to reach Ajenti with valid client certificate, with invalid client certificate or without client certificate,
- SSLContext CERT_REQUIRED ( force client auth ) : trying to reach Ajenti with valid client certificate, with invalid client certificate or without client certificate.

Notice about the tests : 

1. In CERT_OPTIONAL context, an user can reach ajenti even with invalid certificate ( with I consider as ok ),
2. In all tests, the client auth certificate just let the user to possibly reach Ajenti, but not to log the user into Ajenti. I didn't manage to log in in the previous version of Ajenti, this is still to be fixed,
3. In CERT_REQUIRED context, an user with old client certificate from the server can anyway reach Ajenti, even if the certificate digest is no longer part of `/etc/ajenti/config.yml`. I also have to fix it.
4. All other tests were successfull.

The points 2. and 3. need to reconsider the use of a callback function in the sslcontext ( I let an example as comment in `core.py` ) : 

`context.set_servername_callback(AuthenticationService.get(aj.context).client_certificate_callback)`

The method `set_servername_callback()` sends the socket, servername and sslcontext to the callback function. Problem is, I didn't manage to retrieve the peer cert this way in `AuthenticationService.client_certificate_callback()`, but only in `wsgi.py`.
The method `AuthenticationService.client_certificate_callback()` must return None to allow the TLS connection to continue.

So, I think that with the whole code above, it's easier to discuss about a solution for this problem.

