### PR TITLE
401

### DIFF
--- a/ajenti-core/aj/http.py
+++ b/ajenti-core/aj/http.py
@@ -257,6 +257,14 @@ class HttpContext(object):
         self.respond('500 Server Error')
         return [b'Server Error']
 
+
+    def respond_unauthenticated(self):
+        """
+        Returns a HTTP ``401 Unauthenticated`` response
+        """
+        self.respond('401 Unauthenticated')
+        return [b'Unauthenticated']
+
     def respond_forbidden(self):
         """
         Returns a HTTP ``403 Forbidden`` response

--- a/ajenti-core/aj/log.py
+++ b/ajenti-core/aj/log.py
@@ -59,7 +59,7 @@ class ConsoleHandler(logging.StreamHandler):
         if aj.debug:
             s += colored(
                 ('%15s:%-4s  ' % (record.filename[-15:], record.lineno)),
-                'grey',
+                'magenta',
                 attrs=['bold']
             )
 

--- a/ajenti-core/aj/security/verifier.py
+++ b/ajenti-core/aj/security/verifier.py
@@ -15,5 +15,5 @@ class ClientCertificateVerificator(object):
         digest = x509.digest('sha1')
         # logging.debug('SSL verify: %s / %s' % (x509.get_subject(), digest))
         for c in aj.config.data['ssl']['client_auth']['certificates']:
-            if long(c['serial']) == serial and c['digest'] == digest:
+            if long(c['serial']) == serial and c['digest'].encode('utf-8') == digest:
                 return c['user']

--- a/ajenti-core/aj/wsgi.py
+++ b/ajenti-core/aj/wsgi.py
@@ -13,6 +13,7 @@ class RequestHandler(SocketIOHandler):
     def get_environ(self):
         env = SocketIOHandler.get_environ(self)
         env['SSL'] = isinstance(self.socket, gevent.ssl.SSLSocket)
+        env['SSL_CLIENT_AUTH_FORCE'] = aj.config.data['ssl']['client_auth']['force']
         env['SSL_CLIENT_VALID'] = False
         env['SSL_CLIENT_USER'] = None
         if env['SSL']:


### PR DESCRIPTION
Throw 401 if client auth is forced and client cert is not valid.
I didn't find an easy way to do it in AuthenticationMiddleware, because even if the response of AuthenticationMiddleware handle method is 401, CentralDispatcher would provide an answer.

So I tried the following : the 401 error is thrown through CentralDispatcher.