### PR TITLE
Ignore disconnect event from socketio.

### DIFF
--- a/ajenti-core/aj/gate/stream.py
+++ b/ajenti-core/aj/gate/stream.py
@@ -74,8 +74,9 @@ class GateStreamServerEndpoint(object):
 
     def send(self, obj):
         rq = GateStreamRequest(obj, self)
-        for part in _seq_split(json.dumps(rq.serialize())):
-            self.pipe.put(part)
+        if not self.pipe._reader._closed:
+            for part in _seq_split(json.dumps(rq.serialize())):
+                self.pipe.put(part)
         if self.log:
             logging.debug('%s: >> %s', self, rq.id)
         return rq


### PR DESCRIPTION
[When a session is destroyed, it stops the gate](https://github.com/ajenti/ajenti/blob/92d184672fcc96b8872e9d3d4edf15aff05f7d73/ajenti-core/aj/gate/session.py#L37), and then[ it closes the GIPC pipe server side](https://github.com/ajenti/ajenti/blob/92d184672fcc96b8872e9d3d4edf15aff05f7d73/ajenti-core/aj/gate/gate.py#L73).[ This commit was necessary to avoid having too many files descriptors remaining](https://github.com/ajenti/ajenti/commit/67e09d50d9716694cbfb3a4160b2cec01d3c19f5) in `/proc/PID/fd`.

But after that, [Ajenti receive a disconnect event from socketio](https://github.com/ajenti/ajenti/blob/92d184672fcc96b8872e9d3d4edf15aff05f7d73/ajenti-core/aj/gate/middleware.py#L63), and [wants to send this further](https://github.com/ajenti/ajenti/blob/92d184672fcc96b8872e9d3d4edf15aff05f7d73/ajenti-core/aj/gate/worker.py#L151) in order to [destroy the WorkerSocketNS and cleanup](https://github.com/ajenti/ajenti/blob/92d184672fcc96b8872e9d3d4edf15aff05f7d73/ajenti-core/aj/gate/worker.py#L42).  This cannot be done because the GIPC pipe is already closed, so I get this error (and the namespaces is not deleted) : 

```
Socket 140127544194384 disconnected
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 766, in gevent._greenlet.Greenlet.run
  File "/usr/local/lib/python2.7/dist-packages/socketio/transports.py", line 255, in send_into_ws
    socket.disconnect()
  File "/usr/local/lib/python2.7/dist-packages/socketio/virtsocket.py", line 315, in disconnect
    ns.recv_disconnect()
  File "/srv/ajenti/ajenti-panel/aj/gate/middleware.py", line 65, in recv_disconnect
    self._send_worker_event('disconnect')
  File "/srv/ajenti/ajenti-panel/aj/gate/middleware.py", line 49, in _send_worker_event
    'message': message,
  File "/srv/ajenti/ajenti-panel/aj/gate/stream.py", line 78, in send
    self.pipe.put(part)
  File "/usr/local/lib/python2.7/dist-packages/gipc/gipc.py", line 1037, in put
    self._validate()
  File "/usr/local/lib/python2.7/dist-packages/gipc/gipc.py", line 682, in _validate
    "GIPCHandle has been closed before.")
GIPCClosed: GIPCHandle has been closed before.
2020-02-28T21:28:51Z <Greenlet at 0x7f71fc7d08d0: send_into_ws> failed with GIPCClosed
```
I tried many solutions to try to stop the gate after receiving the disconnect, but didn't manage to do it properly, so I'm only suggesting to ignore this error in stream.py. It particularly, I tried to send a stop event to gate ( same way as for terminate ), but it doesn't reach the WorgerGate. Maybe you have 
a better idea ?