### PR TITLE
Some fix about terminal plugin

### DIFF
--- a/plugins/packages/resources/js/controllers/index.controller.es
+++ b/plugins/packages/resources/js/controllers/index.controller.es
@@ -53,7 +53,7 @@ angular.module('ajenti.packages').controller('PackagesIndexController', function
         packages.applySelection($scope.managerId, $scope.selection).then((data) => {
             $scope.selection = [];
             let cmd = data.terminalCommand;
-            terminals.create({command: cmd, autoclose: true}).then((id) => {
+            terminals.create({command: cmd, autoclose: true, redirect: `/view/packages/${$scope.managerId}`}).then((id) => {
                 $location.path(`${urlPrefix}/view/terminal/${id}`);
             });
         })

--- a/plugins/terminal/resources/js/controllers/index.controller.es
+++ b/plugins/terminal/resources/js/controllers/index.controller.es
@@ -7,7 +7,7 @@ angular.module('ajenti.terminal').controller('TerminalIndexController', ($scope,
         });
     };
 
-    $scope.create = () => terminals.create().then(id => $location.path(`/view/terminal/${id}`));
+    $scope.create = () => terminals.create({autoclose:true}).then(id => $location.path(`/view/terminal/${id}`));
 
     $scope.runCommand = () => terminals.create({command: $scope.command, autoclose: true}).then(id => $location.path(`/view/terminal/${id}`));
 

--- a/plugins/terminal/resources/js/controllers/view.controller.es
+++ b/plugins/terminal/resources/js/controllers/view.controller.es
@@ -1,4 +1,4 @@
-angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, $routeParams, $http, $location, hotkeys, pageTitle) => {
+angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, $routeParams, $interval, terminals, hotkeys, pageTitle) => {
     pageTitle.set('Terminal');
 
     $scope.id = $routeParams.id;
@@ -18,10 +18,19 @@ angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, 
             return true;
         }
         if (k === 'D' && e.ctrlKey) {
-            $http.get(`/api/terminal/kill/${$scope.id}`);
-            $location.path(`/view/terminal`);
+            terminals.kill($scope.id);
             return true;
         }
+    });
+
+    $scope.check = () => {
+        terminals.is_dead($scope.id);
+    }
+
+    $scope.redirect_if_dead = $interval($scope.check, 4000, 0);
+
+    $scope.$on('$destroy', function() {
+        $interval.cancel($scope.redirect_if_dead);
     });
 
     $scope.hideCopyDialogVisible = () => $scope.copyDialogVisible = false;

--- a/plugins/terminal/resources/js/controllers/view.controller.es
+++ b/plugins/terminal/resources/js/controllers/view.controller.es
@@ -1,4 +1,4 @@
-angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, $routeParams, hotkeys, pageTitle) => {
+angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, $routeParams, $http, $location, hotkeys, pageTitle) => {
     pageTitle.set('Terminal');
 
     $scope.id = $routeParams.id;
@@ -15,6 +15,11 @@ angular.module('ajenti.terminal').controller('TerminalViewController', ($scope, 
         }
         if (k === 'V' && e.ctrlKey && e.shiftKey) {
             $scope.$broadcast('terminal:paste');
+            return true;
+        }
+        if (k === 'D' && e.ctrlKey) {
+            $http.get(`/api/terminal/kill/${$scope.id}`);
+            $location.path(`/view/terminal`);
             return true;
         }
     });

--- a/plugins/terminal/resources/js/services/terminals.service.es
+++ b/plugins/terminal/resources/js/services/terminals.service.es
@@ -16,8 +16,9 @@ angular.module('ajenti.terminal').service('terminals', function($http, $q, $loca
 
     this.kill = function(id) {
         return $http.get(`/api/terminal/kill/${id}`).then((response) => {
+            let redirect = response.data;
             notify.info(gettext('You will be redirect to the previous page.'));
-            return $timeout(() => $location.path(`/view/terminal`), 3000);
+            return $timeout(() => $location.path(redirect), 3000);
         })
     };
 

--- a/plugins/terminal/resources/js/services/terminals.service.es
+++ b/plugins/terminal/resources/js/services/terminals.service.es
@@ -1,4 +1,4 @@
-angular.module('ajenti.terminal').service('terminals', function($http, $q, $location) {
+angular.module('ajenti.terminal').service('terminals', function($http, $q, $location, $timeout, notify, gettext) {
     this.script = function(options) {
         return $http.post('/api/terminal/script', options).then(response => response.data)
     };
@@ -15,7 +15,18 @@ angular.module('ajenti.terminal').service('terminals', function($http, $q, $loca
     };
 
     this.kill = function(id) {
-        return $http.get(`/api/terminal/kill/${id}`).then(response => response.data)
+        return $http.get(`/api/terminal/kill/${id}`).then((response) => {
+            notify.info(gettext('You will be redirect to the previous page.'));
+            return $timeout(() => $location.path(`/view/terminal`), 3000);
+        })
+    };
+
+    this.is_dead = function(id) {
+        return $http.get(`/api/terminal/is_dead/${id}`, {ignoreLoadingBar: true}).then((response) => {
+            if (response.data === true) {
+                return this.kill(id);
+            };
+        })
     };
 
     this.create = function(options) {

--- a/plugins/terminal/terminal.py
+++ b/plugins/terminal/terminal.py
@@ -17,13 +17,17 @@ from aj.util import BroadcastQueue
 
 
 class Terminal(object):
-    def __init__(self, manager=None, id=None, command=None, autoclose=False, autoclose_retain=5):
+    def __init__(self, manager=None, id=None, command=None, autoclose=False, autoclose_retain=5, redirect=None):
         self.width = 80
         self.height = 25
         self.id = id
         self.manager = manager
         self.autoclose = autoclose
         self.autoclose_retain = autoclose_retain
+        if redirect:
+            self.redirect = redirect
+        else:
+            self.redirect = '/view/terminal'
         self.output = BroadcastQueue()
 
         env = {}

--- a/plugins/terminal/views.py
+++ b/plugins/terminal/views.py
@@ -63,8 +63,10 @@ class Handler(HttpPlugin):
     @endpoint(api=True)
     def handle_kill(self, http_context, terminal_id=None):
         if terminal_id in self.mgr:
-            return self.mgr.kill(terminal_id)
-        return None
+            redirect = self.mgr[terminal_id].redirect
+            self.mgr.kill(terminal_id)
+            return redirect
+        return '/view/terminal'
 
     @url(r'/api/terminal/full/(?P<terminal_id>.+)')
     @endpoint(api=True)

--- a/plugins/terminal/views.py
+++ b/plugins/terminal/views.py
@@ -40,6 +40,13 @@ class Handler(HttpPlugin):
             'stderr': e,
         }
 
+    @url('/api/terminal/is_dead/(?P<terminal_id>.+)')
+    @endpoint(api=True)
+    def handle_test_dead(self, http_context, terminal_id=None):
+        if terminal_id in self.mgr:
+            return self.mgr[terminal_id].dead
+        return True
+
     @url('/api/terminal/list')
     @endpoint(api=True)
     def handle_list(self, http_context):
@@ -55,7 +62,9 @@ class Handler(HttpPlugin):
     @url(r'/api/terminal/kill/(?P<terminal_id>.+)')
     @endpoint(api=True)
     def handle_kill(self, http_context, terminal_id=None):
-        return self.mgr.kill(terminal_id)
+        if terminal_id in self.mgr:
+            return self.mgr.kill(terminal_id)
+        return None
 
     @url(r'/api/terminal/full/(?P<terminal_id>.+)')
     @endpoint(api=True)

--- a/plugins/terminal/views.py
+++ b/plugins/terminal/views.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageDraw
 
-from six import StringIO
+from six import BytesIO
 import subprocess
 
 from jadi import component
@@ -107,7 +107,7 @@ class Handler(HttpPlugin):
                 draw.point((x, y * 2 + 1), fill=(fc if ord(ch) > 32 else bc))
                 draw.point((x, y * 2), fill=bc)
 
-        sio = StringIO()
+        sio = BytesIO()
         img.save(sio, 'PNG')
 
         http_context.add_header('Content-Type', 'image/png')


### PR DESCRIPTION
Here a quick list : 

- fix preview ( bytesIO in PY3 )
- always autoclosing to close remaining terminals
- add hotkeys Ctrl+D to exit
- Redirect to custom URL is terminal is dead ( check all 4s through $interval )
- Redirect to previous package manager if install/remove action (pip or apt)