### PR TITLE
Suggestion to directly retrieve plugins infos from Pypi.

### DIFF
--- a/official_plugins.json
+++ b/official_plugins.json
@@ -1,1 +1,1 @@
-{"plugins":["ace","augeas","auth_users","core","dashboard","datetime","filemanager","filesystem","network","notepad","packages","passwd","plugins","power","services","settings","supervisor","terminal","traffic"]}
+{"plugins":["ace","augeas","auth-users","core","dashboard","datetime","filemanager","filesystem","network","notepad","packages","passwd","plugins","power","services","settings","supervisor","terminal","traffic"]}

--- a/official_plugins.json
+++ b/official_plugins.json
@@ -1,0 +1,1 @@
+{"plugins":["ace","augeas","auth_users","core","dashboard","datetime","filemanager","filesystem","network","notepad","packages","passwd","plugins","power","services","settings","supervisor","terminal","traffic"]}

--- a/plugins/plugins/resources/js/controllers/index.controller.es
+++ b/plugins/plugins/resources/js/controllers/index.controller.es
@@ -8,7 +8,6 @@ angular.module('core').config($routeProvider => {
 angular.module('ajenti.plugins').controller('PluginsIndexController', function($scope, $q, $http, $rootScope, notify, pageTitle, messagebox, tasks, core, gettext) {
     pageTitle.set('Plugins');
 
-    $scope.officialKeyFingerprint = '425E 018E 2394 4B4B 4281  4EE0 BDC3 FBAA 5302 9759';
     $scope.selectedInstalledPlugin = null;
     $scope.selectedRepoPlugin = null;
     $scope.coreUpgradeAvailable = null;
@@ -47,8 +46,8 @@ angular.module('ajenti.plugins').controller('PluginsIndexController', function($
             $http.get('/api/plugins/getpypi/list').success((data) => {
                 $scope.repoList = data;
                 $scope.notInstalledRepoList = $scope.repoList.filter((x) => !$scope.isInstalled(x)).map((x) => x);
-                $scope.repoListOfficial = $scope.repoList.filter((x) => x.signature === $scope.officialKeyFingerprint).map((x) => x);
-                $scope.repoListCommunity = $scope.repoList.filter((x) => x.signature !== $scope.officialKeyFingerprint).map((x) => x);
+                $scope.repoListOfficial = $scope.repoList.filter((x) => x.type === "official").map((x) => x);
+                $scope.repoListCommunity = $scope.repoList.filter((x) => x.type !== "official").map((x) => x);
             }, err => {
                 notify.error(gettext('Could not load plugin repository'), err.message)
             });

--- a/plugins/plugins/resources/js/controllers/index.controller.es
+++ b/plugins/plugins/resources/js/controllers/index.controller.es
@@ -38,6 +38,15 @@ angular.module('ajenti.plugins').controller('PluginsIndexController', function($
         return false;
     }
 
+    $scope.testPypi = false;
+    $scope.checkPypi = () => {
+       $http.get('/api/plugins/testpypi/list').success((data) => {
+            for (let pl of data) {
+                console.log(pl);
+            }
+        });
+    }
+
     $scope.refresh = () => {
         $http.get('/api/plugins/list/installed').success((data) => {
             $scope.installedPlugins = data;

--- a/plugins/plugins/resources/js/controllers/index.controller.es
+++ b/plugins/plugins/resources/js/controllers/index.controller.es
@@ -38,22 +38,13 @@ angular.module('ajenti.plugins').controller('PluginsIndexController', function($
         return false;
     }
 
-    $scope.testPypi = false;
-    $scope.checkPypi = () => {
-       $http.get('/api/plugins/testpypi/list').success((data) => {
-            for (let pl of data) {
-                console.log(pl);
-            }
-        });
-    }
-
     $scope.refresh = () => {
         $http.get('/api/plugins/list/installed').success((data) => {
             $scope.installedPlugins = data;
             $scope.repoList = null;
             $scope.repoListOfficial = null;
             $scope.repoListCommunity = null;
-            $http.get('/api/plugins/repo/list').success((data) => {
+            $http.get('/api/plugins/getpypi/list').success((data) => {
                 $scope.repoList = data;
                 $scope.notInstalledRepoList = $scope.repoList.filter((x) => !$scope.isInstalled(x)).map((x) => x);
                 $scope.repoListOfficial = $scope.repoList.filter((x) => x.signature === $scope.officialKeyFingerprint).map((x) => x);

--- a/plugins/plugins/resources/partial/index.html
+++ b/plugins/plugins/resources/partial/index.html
@@ -12,6 +12,9 @@
     <div ng:show="!coreUpgradeAvailable">
         <div class="alert alert-info">
             <i class="fa fa-info-circle"></i> <span translate>Ajenti core {{ajentiVersion}}, no upgrades available.</span>
+            <a ng:click="checkPypi()" ng:show="testPypi" class="btn btn-primary pull-right">
+                <i class="fa fa-arrow-up"></i> <span translate>Check packages by Pypi</span>
+            </a>
         </div>
     </div>
 

--- a/plugins/plugins/resources/partial/index.html
+++ b/plugins/plugins/resources/partial/index.html
@@ -12,9 +12,6 @@
     <div ng:show="!coreUpgradeAvailable">
         <div class="alert alert-info">
             <i class="fa fa-info-circle"></i> <span translate>Ajenti core {{ajentiVersion}}, no upgrades available.</span>
-            <a ng:click="checkPypi()" ng:show="testPypi" class="btn btn-primary pull-right">
-                <i class="fa fa-arrow-up"></i> <span translate>Check packages by Pypi</span>
-            </a>
         </div>
     </div>
 


### PR DESCRIPTION
Hello @Eugeny ,

**This is not finished**, it's only a suggestion to get the plugins states from Pypi instead of http://ajenti.org/plugins/list. If you're ok with this method, I will finish it, or we can drop it and let the actual method.

Some notices about it : 

- it makes a request to https://pypi.org/simple and parses it with bs4, which introduces a dependency to bs4,
- then, it makes concurrent requests (Python3 !) for each plugin. This can also be made with angularjs
- it takes a long time to get the infos (more than 15s), that's why I introduce a check button to check it manually, and not when the page is loading.

What do you think about it ?