### PR TITLE
Padding places cursor at wrong position.

### DIFF
--- a/plugins/ace/resources/css/ace.less
+++ b/plugins/ace/resources/css/ace.less
@@ -11,6 +11,3 @@ ace-editor {
     padding-right: 10px;
 }
 
-.ace_content {
-    padding-left: 10px;
-}


### PR DESCRIPTION
Padding in `.ace_content` causes the cursor to be falsy placed in some cases, which is pretty disturbing to edit files, please see : https://github.com/angular-ui/ui-ace/issues/115

Simply remove the padding seems to solve the issue, tested with FF, chrome on Linux + W10.