### PR TITLE
Add oracle linux server to platform detection.

### DIFF
--- a/ajenti-core/aj/__init__.py
+++ b/ajenti-core/aj/__init__.py
@@ -84,6 +84,7 @@ def detect_platform():
         'amazon': 'ubuntu',
         'redhat enterprise linux': 'rhel',
         'red hat enterprise linux server': 'rhel',
+        'oracle linux server': 'rhel',
         'fedora': 'rhel',
         'olpc': 'rhel',
         'xo-system': 'rhel',


### PR DESCRIPTION
Added oracle linux server =, it did not work for the network and datetime plugins, and probably others.