### PR TITLE
Sec

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -13,3 +13,4 @@ enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  additional_builtins = ["_"]

--- a/ajenti-core/aj/__init__.py
+++ b/ajenti-core/aj/__init__.py
@@ -104,13 +104,13 @@ def detect_platform():
         return res, res
 
     dist = ''
-    (maj, min, _) = pyplatform.python_version_tuple()
-    maj = int(maj)
-    min = int(min)
-    if (maj * 10 + min) >= 36:
+    (major, minor, _) = pyplatform.python_version_tuple()
+    major = int(major)
+    minor = int(minor)
+    if (major * 10 + minor) >= 36:
         import distro
         dist = distro.linux_distribution()[0].split()[0]
-    elif (maj * 10 + min) >= 26:
+    elif (major * 10 + minor) >= 26:
         dist = pyplatform.linux_distribution()[0]
     else:
         dist = pyplatform.dist()[0]
@@ -164,7 +164,7 @@ def init():
     aj.platform_string = detect_platform_string()
     aj.python_version = detect_python()
 
-
+# skipcq: PYL-W0622
 def exit():
     os.kill(os.getpid(), signal.SIGQUIT)
 

--- a/ajenti-core/aj/api/http.py
+++ b/ajenti-core/aj/api/http.py
@@ -86,8 +86,8 @@ class HttpPlugin():
                         data = data.encode('utf-8')
                     if isinstance(data, types.GeneratorType):
                         return data
-                    else:
-                        return [data]
+
+                    return [data]
 
 
 @interface

--- a/ajenti-core/aj/auth.py
+++ b/ajenti-core/aj/auth.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import pexpect
 import pwd

--- a/ajenti-core/aj/auth.py
+++ b/ajenti-core/aj/auth.py
@@ -118,8 +118,7 @@ class OSAuthenticationProvider(AuthenticationProvider):
             return False
         if result == 0:
             return False
-        else:
-            return True
+        return True
 
     def authorize(self, username, permission):
         return True
@@ -220,8 +219,7 @@ class authorize():
             if permission['id'] == self.permission_id:
                 if provider.authorize(username, permission):
                     break
-                else:
-                    raise SecurityError(self.permission_id)
+                raise SecurityError(self.permission_id)
         else:
             raise SecurityError(self.permission_id)
 

--- a/ajenti-core/aj/config.py
+++ b/ajenti-core/aj/config.py
@@ -106,7 +106,7 @@ class UserConfig(UserConfigProvider):
             self.data = {}
 
     def load(self):
-        self.data = yaml.load(open(self.path), Loader=yaml.Loader)
+        self.data = yaml.load(open(self.path), Loader=yaml.SafeLoader)
 
     def harden(self):
         os.chmod(self.path, stat.S_IRWXU)

--- a/ajenti-core/aj/entry.py
+++ b/ajenti-core/aj/entry.py
@@ -3,8 +3,6 @@ import logging
 import traceback
 from datetime import datetime
 
-import aj
-import aj.log
 from aj.util.pidfile import PidFile
 
 

--- a/ajenti-core/aj/gate/stream.py
+++ b/ajenti-core/aj/gate/stream.py
@@ -9,10 +9,10 @@ MSG_SIZE_LIMIT = 1024 * 1024 * 128  # 128 MB
 MSG_CONTINUATION_MARKER = '\x00\x00\x00continued\x00\x00\x00'
 
 
-def _seq_split(object):
-    while object:
-        yield object[:MSG_SIZE_LIMIT] + (MSG_CONTINUATION_MARKER if len(object) > MSG_SIZE_LIMIT else '')
-        object = object[MSG_SIZE_LIMIT:]
+def _seq_split(to_split):
+    while to_split:
+        yield to_split[:MSG_SIZE_LIMIT] + (MSG_CONTINUATION_MARKER if len(to_split) > MSG_SIZE_LIMIT else '')
+        to_split = to_split[MSG_SIZE_LIMIT:]
 
 
 def _seq_is_continued(part):
@@ -20,11 +20,11 @@ def _seq_is_continued(part):
 
 
 def _seq_combine(parts):
-    object = ''
+    full_object = ''
     for part in parts[:-1]:
-        object += part[len(MSG_CONTINUATION_MARKER):]
-    object += parts[-1]
-    return object
+        full_object += part[len(MSG_CONTINUATION_MARKER):]
+    full_object += parts[-1]
+    return full_object
 
 
 class GateStreamRequest():

--- a/ajenti-core/aj/gate/worker.py
+++ b/ajenti-core/aj/gate/worker.py
@@ -90,10 +90,10 @@ class Worker():
 
         if os.getuid() == uid:
             return
-        else:
-            if os.getuid() != 0:
-                logging.warning('Running as a limited user, setuid() unavailable!')
-                return
+
+        if os.getuid() != 0:
+            logging.warning('Running as a limited user, setuid() unavailable!')
+            return
 
         logging.info(
             'Worker %s is demoting to UID %s / GID %s...',

--- a/ajenti-core/aj/plugins.py
+++ b/ajenti-core/aj/plugins.py
@@ -89,7 +89,10 @@ class PluginCrashed(PluginLoadError):
 
 
 @public
-class Dependency():
+class Dependency(yaml.YAMLObject):
+    yaml_loader = yaml.SafeLoader
+    yaml_tag = u'!Dependency'
+
     class Unsatisfied(PluginLoadError):
         def __init__(self):
             PluginLoadError.__init__(self, None)
@@ -122,6 +125,7 @@ class Dependency():
 @public
 class ModuleDependency(Dependency):
     description = 'Python module'
+    yaml_tag = u'!ModuleDependency'
 
     class Unsatisfied(Dependency.Unsatisfied):
         def reason(self):
@@ -146,6 +150,7 @@ class ModuleDependency(Dependency):
 @public
 class PluginDependency(Dependency):
     description = 'Plugin'
+    yaml_tag = u'!PluginDependency'
 
     class Unsatisfied(Dependency.Unsatisfied):
         def reason(self):
@@ -164,6 +169,7 @@ class PluginDependency(Dependency):
 @public
 class OptionalPluginDependency(Dependency):
     description = 'Plugin'
+    yaml_tag = u'!OptionalPluginDependency'
 
     class Unsatisfied(Dependency.Unsatisfied):
         def reason(self):
@@ -182,6 +188,7 @@ class OptionalPluginDependency(Dependency):
 @public
 class BinaryDependency(Dependency):
     description = 'Application binary'
+    yaml_tag = u'!BinaryDependency'
 
     class Unsatisfied(Dependency.Unsatisfied):
         def reason(self):
@@ -200,6 +207,7 @@ class BinaryDependency(Dependency):
 @public
 class FileDependency(Dependency):
     description = 'File'
+    yaml_tag = u'!FileDependency'
 
     class Unsatisfied(Dependency.Unsatisfied):
         def reason(self):
@@ -263,7 +271,7 @@ class PluginManager():
 
         self.__plugin_info = {}
         for path in found:
-            yml_info = yaml.load(open(os.path.join(path, 'plugin.yml')), Loader=yaml.Loader)
+            yml_info = yaml.load(open(os.path.join(path, 'plugin.yml')), Loader=yaml.SafeLoader)
             yml_info['resources'] = [
                 ({'path': x} if isinstance(x, str) else x)
                 for x in yml_info.get('resources', [])

--- a/ajenti-core/requirements.txt
+++ b/ajenti-core/requirements.txt
@@ -12,7 +12,7 @@ passlib
 pexpect
 psutil>=2.2.1
 pyOpenSSL==19.1.0
-python-daemon-3k
+python-daemon
 pyyaml
 requests>=2
 setproctitle

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,6 @@ pygments_style = 'sphinx'
 
 
 # ReadTheDocs
-import os
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
@@ -86,12 +85,13 @@ class Mock():
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):
             return '/dev/null'
-        elif name[0] == name[0].upper():
+
+        if name[0] == name[0].upper():
             mockType = type(name, (), {})
             mockType.__module__ = __name__
             return mockType
-        else:
-            return Mock()
+
+        return Mock()
 
 MOCK_MODULES = [
     'augeas',
@@ -130,7 +130,6 @@ for mod_name in MOCK_MODULES:
 
 
 
-import aj
 import aj.api
 import aj.config
 import aj.core

--- a/plugins/ace/plugin.yml
+++ b/plugins/ace/plugin.yml
@@ -6,7 +6,7 @@ version: '0.28'
 title: 'Ace editor'
 icon: cog
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/css/ace.less
     - resources/js/module.es

--- a/plugins/augeas/plugin.yml
+++ b/plugins/augeas/plugin.yml
@@ -6,7 +6,7 @@ version: '0.17'
 title: 'Augeas API'
 icon: cog
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/services/augeas.service.es

--- a/plugins/auth_users/api.py
+++ b/plugins/auth_users/api.py
@@ -36,9 +36,9 @@ class UsersAuthenticationProvider(AuthenticationProvider):
         self.context.worker.reload_master_config()
         password = password.encode('utf-8')
         if username in aj.config.data['auth']['users']:
-            hash = aj.config.data['auth']['users'][username]['password']
+            user_hash = aj.config.data['auth']['users'][username]['password']
             try:
-                scrypt.decrypt(hash.decode('hex'), password, maxtime=15)
+                scrypt.decrypt(user_hash.decode('hex'), password, maxtime=15)
                 return True
             except scrypt.error as e:
                 logging.debug('Auth failed: %s' % e)

--- a/plugins/auth_users/plugin.yml
+++ b/plugins/auth_users/plugin.yml
@@ -6,7 +6,7 @@ version: '0.30'
 title: 'Custom users authentication'
 icon: users
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/check_certificates/main.py
+++ b/plugins/check_certificates/main.py
@@ -1,6 +1,6 @@
 from jadi import component
 
-from aj.auth import PermissionProvider
+# from aj.auth import PermissionProvider
 from aj.plugins.core.api.sidebar import SidebarItemProvider
 
 

--- a/plugins/check_certificates/plugin.yml
+++ b/plugins/check_certificates/plugin.yml
@@ -6,7 +6,7 @@ version: '0.5'
 title: 'Check certificates'
 icon: certificate
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/check_certificates/views.py
+++ b/plugins/check_certificates/views.py
@@ -5,8 +5,8 @@ Module to check if some certificates are still valid or not.
 from jadi import component
 
 from aj.api.http import url, HttpPlugin
-from aj.auth import authorize
-from aj.api.endpoint import endpoint, EndpointError
+# from aj.auth import authorize
+from aj.api.endpoint import endpoint
 from .api import checkOnDom
 import simplejson as json
 

--- a/plugins/core/views/api.py
+++ b/plugins/core/views/api.py
@@ -2,9 +2,7 @@ import gevent
 import simplejson as json
 import os
 import socket
-import traceback
 from jadi import component
-from datetime import timedelta
 from time import time
 
 import aj

--- a/plugins/core/views/api.py
+++ b/plugins/core/views/api.py
@@ -103,12 +103,13 @@ class Handler(HttpPlugin):
                     'success': True,
                     'username': username,
                 }
-            else:
-                gevent.sleep(3)
-                return {
-                    'success': False,
-                    'error': None,
-                }
+
+            gevent.sleep(3)
+            return {
+                'success': False,
+                'error': None,
+            }
+
         elif mode == 'sudo':
             target = 'root'
             try:
@@ -118,12 +119,12 @@ class Handler(HttpPlugin):
                         'success': True,
                         'username': target,
                     }
-                else:
-                    gevent.sleep(3)
-                    return {
-                        'success': False,
-                        'error': _('Authorization failed'),
-                    }
+
+                gevent.sleep(3)
+                return {
+                    'success': False,
+                    'error': _('Authorization failed'),
+                }
             except SudoError as e:
                 gevent.sleep(3)
                 return {
@@ -228,12 +229,12 @@ class Handler(HttpPlugin):
 
         if aj.dev_autologin:
             return 86400
-        else:
-            self.context.worker.update_sessionlist()
-            # Wait until the new values propagate
-            gevent.sleep(0.01)
-            session_max_time = aj.config.data['session_max_time'] if aj.config.data['session_max_time'] else 3600
-            timestamp = 0
-            if self.context.session.key in aj.sessions.keys():
-                timestamp = aj.sessions[self.context.session.key]['timestamp']
-            return int(timestamp + session_max_time - time())
+
+        self.context.worker.update_sessionlist()
+        # Wait until the new values propagate
+        gevent.sleep(0.01)
+        session_max_time = aj.config.data['session_max_time'] if aj.config.data['session_max_time'] else 3600
+        timestamp = 0
+        if self.context.session.key in aj.sessions.keys():
+            timestamp = aj.sessions[self.context.session.key]['timestamp']
+        return int(timestamp + session_max_time - time())

--- a/plugins/core/views/main.py
+++ b/plugins/core/views/main.py
@@ -31,8 +31,7 @@ class Handler(HttpPlugin):
 
         if self.context.identity:
             return http_context.redirect('/view/')
-        else:
-            return http_context.redirect('/view/login/normal')
+        return http_context.redirect('/view/login/normal')
 
     @url('/view/.*')
     @endpoint(page=True, auth=False)

--- a/plugins/core/views/main.py
+++ b/plugins/core/views/main.py
@@ -1,4 +1,3 @@
-import gevent
 import json
 import logging
 import subprocess

--- a/plugins/cron/plugin.yml
+++ b/plugins/cron/plugin.yml
@@ -6,7 +6,7 @@ version: '0.2'
 title: 'cron'
 icon: 'clock-o'
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency {
+    - !PluginDependency {
         plugin_name: core
     }
 resources:

--- a/plugins/dashboard/plugin.yml
+++ b/plugins/dashboard/plugin.yml
@@ -6,7 +6,7 @@ version: '0.38'
 title: 'Dashboard'
 icon: bar-chart
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/dashboard/views.py
+++ b/plugins/dashboard/views.py
@@ -2,7 +2,6 @@
 Manage a widget page and refresh all values automatically.
 """
 
-import json
 from jadi import component
 
 from aj.api.http import url, HttpPlugin

--- a/plugins/dashboard/widgets/loadavg.py
+++ b/plugins/dashboard/widgets/loadavg.py
@@ -21,6 +21,6 @@ class LoadAverageWidget(Widget):
             k /= multiprocessing.cpu_count()
         if os.path.exists('/proc/loadavg'):
             return [float(open('/proc/loadavg').read().split()[x]) * k for x in range(3)]
-        else:
-            tokens = subprocess.check_output(['uptime']).split()
-            return [float(x.strip(',')) * k for x in tokens[-3:]]
+
+        tokens = subprocess.check_output(['uptime']).split()
+        return [float(x.strip(',')) * k for x in tokens[-3:]]

--- a/plugins/datetime/__init__.py
+++ b/plugins/datetime/__init__.py
@@ -8,5 +8,5 @@ def init(plugin_manager):
     import aj
     api.TZManager.any(aj.context)
 
-    from .main import ItemProvider
-    from .views import Handler
+    from .main import ItemProvider # skipcq: PYL-W0611
+    from .views import Handler # skipcq: PYL-W0611

--- a/plugins/datetime/plugin.yml
+++ b/plugins/datetime/plugin.yml
@@ -6,7 +6,7 @@ version: '0.38'
 title: 'Date & time'
 icon: clock-o
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/docker/plugin.yml
+++ b/plugins/docker/plugin.yml
@@ -6,7 +6,7 @@ version: '0.2'
 title: 'docker'
 icon: docker
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency {
+    - !PluginDependency {
         plugin_name: core
     }
 resources:

--- a/plugins/docker/views.py
+++ b/plugins/docker/views.py
@@ -7,7 +7,7 @@ import subprocess
 import json
 
 from aj.api.http import url, HttpPlugin
-from aj.auth import authorize
+# from aj.auth import authorize
 from aj.api.endpoint import endpoint, EndpointError
 
 @component(HttpPlugin)

--- a/plugins/filemanager/plugin.yml
+++ b/plugins/filemanager/plugin.yml
@@ -6,8 +6,8 @@ version: '0.26'
 title: 'File Manager'
 icon: folder-o
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: filesystem }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: filesystem }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/filesystem/plugin.yml
+++ b/plugins/filesystem/plugin.yml
@@ -6,8 +6,8 @@ version: '0.46'
 title: 'Filesystem API'
 icon: cog
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.OptionalPluginDependency { plugin_name: dashboard }
+    - !PluginDependency { plugin_name: core }
+    - !OptionalPluginDependency { plugin_name: dashboard }
 resources:
     - resources/vendor/ng-flow/dist/ng-flow-standalone.min.js
     - resources/js/module.es

--- a/plugins/filesystem/widget.py
+++ b/plugins/filesystem/widget.py
@@ -30,9 +30,9 @@ class DiskWidget(Widget):
                 'free': usage[mountpoint].free,
                 'used': usage[mountpoint].used,
             }
-        else:
-            return {
-                'total': None,
-                'free': None,
-                'used': None,
-            }
+
+        return {
+            'total': None,
+            'free': None,
+            'used': None,
+        }

--- a/plugins/fstab/plugin.yml
+++ b/plugins/fstab/plugin.yml
@@ -7,7 +7,7 @@ title: 'fstab'
 icon: hdd
 
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency {
+    - !PluginDependency {
         plugin_name: core
     }
 resources:

--- a/plugins/fstab/views.py
+++ b/plugins/fstab/views.py
@@ -101,8 +101,8 @@ class Handler(HttpPlugin):
 
             for filesystem in config:
                 device = FilesystemData()
-                for property, value in filesystem.items():
-                    setattr(device, property, value)
+                for prop, value in filesystem.items():
+                    setattr(device, prop, value)
                 new_fstab.tree.filesystems.append(device)
 
             data = new_fstab.save()[None]

--- a/plugins/hosts/plugin.yml
+++ b/plugins/hosts/plugin.yml
@@ -7,7 +7,7 @@ title: 'hosts'
 icon: sitemap
 
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency {
+    - !PluginDependency {
         plugin_name: core
     }
 resources:

--- a/plugins/hosts/views.py
+++ b/plugins/hosts/views.py
@@ -43,15 +43,15 @@ class Handler(HttpPlugin):
 
             for host in config:
                 new_host = HostData()
-                for property, value in host.items():
-                    if property == 'aliases':
+                for prop, value in host.items():
+                    if prop == 'aliases':
                         for alias in value:
                             if alias['name'] != '':
                                 new_alias = AliasData()
                                 new_alias.name = alias['name']
                                 new_host.aliases.append(new_alias)
                     else:
-                        setattr(new_host, property, value)
+                        setattr(new_host, prop, value)
                 new_hosts.tree.hosts.append(new_host)
 
             data = new_hosts.save()[None]

--- a/plugins/hosts/views.py
+++ b/plugins/hosts/views.py
@@ -3,7 +3,6 @@ Module to handle the /etc/hosts file with the help of the reconfigure module.
 """
 
 from jadi import component
-import subprocess
 import os
 
 from aj.api.http import url, HttpPlugin

--- a/plugins/network/__init__.py
+++ b/plugins/network/__init__.py
@@ -9,6 +9,6 @@ def init(plugin_manager):
     import aj
     api.NetworkManager.any(aj.context)
 
-    from .aug import ResolvConfEndpoint
-    from .main import ItemProvider
-    from .views import Handler
+    from .aug import ResolvConfEndpoint # skipcq: PYL-W0611
+    from .main import ItemProvider # skipcq: PYL-W0611
+    from .views import Handler # skipcq: PYL-W0611

--- a/plugins/network/managers/gentoo_manager.py
+++ b/plugins/network/managers/gentoo_manager.py
@@ -5,7 +5,7 @@ import aj
 from aj.plugins.augeas.api import Augeas
 from aj.plugins.network.api import NetworkManager
 
-from .ifconfig import ifconfig_up, ifconfig_down, ifconfig_get_ip, ifconfig_get_up
+from .ifconfig import ifconfig_get_ip, ifconfig_get_up
 
 
 @component(NetworkManager)

--- a/plugins/network/managers/ubuntu_manager.py
+++ b/plugins/network/managers/ubuntu_manager.py
@@ -46,7 +46,7 @@ class UbuntuNetworkManager(NetworkManager):
         ifaces = []
         netplan_files = [join(self.path,f) for f in os.listdir(self.path) if isfile(join(self.path, f))]
         for path in netplan_files:
-            config = yaml.load(open(path), Loader=yaml.Loader)['network']['ethernets']
+            config = yaml.load(open(path), Loader=yaml.SafeLoader)['network']['ethernets']
             for key in config:
                 iface = {
                     'name': key,

--- a/plugins/network/plugin.yml
+++ b/plugins/network/plugin.yml
@@ -6,8 +6,8 @@ version: '0.25'
 title: 'Network'
 icon: plug
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: augeas }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: augeas }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/notepad/plugin.yml
+++ b/plugins/notepad/plugin.yml
@@ -6,9 +6,9 @@ version: '0.26'
 title: 'Notepad'
 icon: pencil
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: ace }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: filesystem }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: ace }
+    - !PluginDependency { plugin_name: filesystem }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/packages/plugin.yml
+++ b/plugins/packages/plugin.yml
@@ -6,8 +6,8 @@ version: '0.32'
 title: 'Packages'
 icon: gift
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: terminal }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: terminal }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/passwd/plugin.yml
+++ b/plugins/passwd/plugin.yml
@@ -6,7 +6,7 @@ version: '0.23'
 title: 'User DB API'
 icon: cog
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/services/passwd.service.es

--- a/plugins/plugins/plugin.yml
+++ b/plugins/plugins/plugin.yml
@@ -6,7 +6,7 @@ version: '0.46'
 title: 'Plugins'
 icon: th-large
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/controllers/index.controller.es

--- a/plugins/power/plugin.yml
+++ b/plugins/power/plugin.yml
@@ -6,8 +6,8 @@ version: '0.21'
 title: 'Power management'
 icon: bolt
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.OptionalPluginDependency { plugin_name: dashboard }
+    - !PluginDependency { plugin_name: core }
+    - !OptionalPluginDependency { plugin_name: dashboard }
 resources:
     - 'resources/js/module.es'
     - 'resources/js/routing.es'

--- a/plugins/services/managers/systemd_manager.py
+++ b/plugins/services/managers/systemd_manager.py
@@ -51,7 +51,7 @@ class SystemdServiceManager(ServiceManager):
                 if len(unit) > 0:
                     svc = Service(self)
                     svc.id = unit['Id']
-                    svc.name, type = svc.id.rsplit('.', 1)
+                    svc.name, _ = svc.id.rsplit('.', 1)
 
                     svc.name = svc.name.replace('\\x2d', '\x2d')
                     svc.running = unit['SubState'] == 'running'

--- a/plugins/services/plugin.yml
+++ b/plugins/services/plugin.yml
@@ -6,8 +6,8 @@ version: '0.29'
 title: 'Services'
 icon: cogs
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.OptionalPluginDependency { plugin_name: dashboard }
+    - !PluginDependency { plugin_name: core }
+    - !OptionalPluginDependency { plugin_name: dashboard }
 resources:
     - 'resources/js/module.es'
     - 'resources/js/routing.es'

--- a/plugins/session_list/main.py
+++ b/plugins/session_list/main.py
@@ -1,6 +1,6 @@
 from jadi import component
 
-from aj.auth import PermissionProvider
+# from aj.auth import PermissionProvider
 from aj.plugins.core.api.sidebar import SidebarItemProvider
 
 

--- a/plugins/session_list/plugin.yml
+++ b/plugins/session_list/plugin.yml
@@ -6,7 +6,7 @@ version: '0.3'
 title: 'Session list'
 icon: network-wired
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: core }
 resources:
     - resources/js/module.es
     - resources/js/routing.es

--- a/plugins/session_list/views.py
+++ b/plugins/session_list/views.py
@@ -6,8 +6,8 @@ process and the root process.
 from jadi import component
 
 from aj.api.http import url, HttpPlugin
-from aj.auth import authorize
-from aj.api.endpoint import endpoint, EndpointError
+# from aj.auth import authorize
+from aj.api.endpoint import endpoint
 import aj
 import gevent
 

--- a/plugins/settings/plugin.yml
+++ b/plugins/settings/plugin.yml
@@ -6,9 +6,9 @@ version: '0.29'
 title: 'Settings'
 icon: wrench
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: filesystem }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: passwd }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: filesystem }
+    - !PluginDependency { plugin_name: passwd }
 resources:
     - 'resources/js/module.es'
     - 'resources/js/routing.es'

--- a/plugins/softraid/plugin.yml
+++ b/plugins/softraid/plugin.yml
@@ -6,7 +6,7 @@ version: '0.1'
 title: 'softraid'
 icon: hdd
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency {
+    - !PluginDependency {
         plugin_name: core
     }
 resources:

--- a/plugins/softraid/views.py
+++ b/plugins/softraid/views.py
@@ -6,7 +6,7 @@ from jadi import component
 
 from aj.api.http import url, HttpPlugin
 # from aj.auth import authorize
-from aj.api.endpoint import endpoint, EndpointError
+from aj.api.endpoint import endpoint
 from aj.plugins.softraid.softraid import RAIDManager
 
 @component(HttpPlugin)

--- a/plugins/supervisor/plugin.yml
+++ b/plugins/supervisor/plugin.yml
@@ -6,11 +6,11 @@ version: '0.17'
 title: 'Supervisor'
 icon: play
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: augeas }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: services }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: passwd }
-    - !!python/object:aj.plugins.BinaryDependency { binary_name: supervisorctl }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: augeas }
+    - !PluginDependency { plugin_name: services }
+    - !PluginDependency { plugin_name: passwd }
+    - !BinaryDependency { binary_name: supervisorctl }
 resources:
     - 'resources/js/module.es'
     - 'resources/js/routing.es'

--- a/plugins/terminal/plugin.yml
+++ b/plugins/terminal/plugin.yml
@@ -6,9 +6,9 @@ version: '0.38'
 title: 'Terminal'
 icon: terminal
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: ace }
-    - !!python/object:aj.plugins.OptionalPluginDependency { plugin_name: dashboard }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: ace }
+    - !OptionalPluginDependency { plugin_name: dashboard }
 resources:
     - 'resources/css/terminal.less'
     - 'resources/js/module.es'

--- a/plugins/terminal/views.py
+++ b/plugins/terminal/views.py
@@ -139,8 +139,7 @@ class Handler(HttpPlugin):
 
         if terminal_id in self.mgr:
             return self.mgr[terminal_id].format(full=True)
-        else:
-            return None
+        return None
 
     colors = {
         'black': '#073642',

--- a/plugins/traffic/plugin.yml
+++ b/plugins/traffic/plugin.yml
@@ -6,8 +6,8 @@ version: '0.14'
 title: 'Traffic Widget'
 icon: exchange
 dependencies:
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: core }
-    - !!python/object:aj.plugins.PluginDependency { plugin_name: dashboard }
+    - !PluginDependency { plugin_name: core }
+    - !PluginDependency { plugin_name: dashboard }
 resources:
     - 'resources/js/module.es'
     - 'resources/js/controllers/widget.controller.es'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,12 +68,17 @@ fi
 
 
 echo ":: Upgrading PIP"
+
 rm /usr/lib/$PYTHON3/dist-packages/setuptools.egg-info || true # for debian 7
 $PYTHON3 -m pip install -U pip wheel setuptools
 $PYTHON3 -m pip uninstall -y gevent-socketio gevent-socketio-hartwork
 
 echo ":: Installing Ajenti"
-$PYTHON3 -m pip install ajenti-panel ajenti.plugin.core ajenti.plugin.dashboard ajenti.plugin.settings ajenti.plugin.plugins ajenti.plugin.notepad ajenti.plugin.terminal ajenti.plugin.filemanager ajenti.plugin.packages ajenti.plugin.services || exit 1
+
+$PYTHON3 -m pip install cookies distro greenlet==0.4.16 gevent==1.3.7 "gevent-socketio-hartwork>=0.3.6" gevent-websocket gipc "jadi>=1.0.3" "lxml>=2.2.4" passlib pexpect "psutil>=2.2.1" pyOpenSSL==19.1.0 python-daemon pyyaml "requests>=2" setproctitle simplejson "six>=1.9.0" termcolor "pip>=20" "setuptools>=41" Pillow python-augeas pytz pyte==0.8.0 scrypt setproctitle reconfigure upstart-new || exit 1
+$PYTHON3 -m pip install --no-deps aj ajenti-panel || exit 1
+$PYTHON3 -m pip install --no-deps ajenti.plugin.core ajenti.plugin.dashboard ajenti.plugin.settings ajenti.plugin.plugins ajenti.plugin.notepad ajenti.plugin.terminal ajenti.plugin.filemanager ajenti.plugin.packages ajenti.plugin.services || exit 1
+# $PYTHON3 -m pip install ajenti-panel ajenti.plugin.core ajenti.plugin.dashboard ajenti.plugin.settings ajenti.plugin.plugins ajenti.plugin.notepad ajenti.plugin.terminal ajenti.plugin.filemanager ajenti.plugin.packages ajenti.plugin.services || exit 1
 
 # ----------------
 


### PR DESCRIPTION
Some corrections notified by deepsource :

- use SafeLoader for yaml, and simplify the tag for the dependency objects from ajenti,
- diverses deepsource corrections (anti-patterns, etc ... ),
- certificate client generation was not running anymore, this is fixed,
- check_certificate was not able to handle timeout,
- breaking change : python-daemon-3k does not seem to be installable anymore, so I change the requirement to python-daemon which also supports p3.