### PR TITLE
Fix dependency conflict with gipc.

### DIFF
--- a/ajenti-core/requirements.txt
+++ b/ajenti-core/requirements.txt
@@ -1,7 +1,7 @@
 # core
 cookies
 distro
-greenlet==0.4.16
+greenlet<=0.4.16
 gevent==1.5.0
 gevent-socketio-hartwork>=0.3.6
 gevent-websocket


### PR DESCRIPTION
`gipc` requires `greenlet<=0.4.15` and `aj` requires `greenlet==0.4.16` so `aj==2.1.38` can not be installed.
Quick fix until `gipc` use a more recent version of `greenlet`.