### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ajenti-core/aj/config.py
+++ b/ajenti-core/aj/config.py
@@ -15,7 +15,7 @@ class BaseConfig():
 
     .. py:attribute:: data
 
-        currenly loaded config content
+        currently loaded config content
 
     """
     def __init__(self):

--- a/docs/source/man/config.rst
+++ b/docs/source/man/config.rst
@@ -82,9 +82,9 @@ Explanations:
      * **enable**: **true** or **false** to enable client authentication via certificates
      * **force**: if **true**, only allows login with client certificate. If **false**, also permit authentication with password
      * **certificates**: this entry contains all client certifcates for an automatic login. It will be filled through the settings in Ajenti with the following structure:
-        * **digest**: digest of the certificat
-        * **name**: name of the certificat
-        * **serial**: serial of the certificat
+        * **digest**: digest of the certificate
+        * **name**: name of the certificate
+        * **serial**: serial of the certificate
         * **user**: username
 
 email block

--- a/docs/source/man/install.rst
+++ b/docs/source/man/install.rst
@@ -25,7 +25,7 @@ Automatic Installation in  virtual environment
 ==============================================
 
 .. CAUTION::
-    Please note that this install method is still under tests. Ajenti starts successfully on the previously mentionned supported operating systems, but all functionalities were not tested. Be kind  to report any problem with this install method as issue here : https://github.com/ajenti/ajenti/issues
+    Please note that this install method is still under tests. Ajenti starts successfully on the previously mentioned supported operating systems, but all functionalities were not tested. Be kind  to report any problem with this install method as issue here : https://github.com/ajenti/ajenti/issues
 
 ::
 

--- a/plugins/cron/views.py
+++ b/plugins/cron/views.py
@@ -40,7 +40,7 @@ class Handler(HttpPlugin):
 
         :param http_context: HttpContext
         :type http_context: HttpContext
-        :return: True if successfull
+        :return: True if successful
         :rtype: bool
         """
 

--- a/plugins/docker/main.py
+++ b/plugins/docker/main.py
@@ -11,7 +11,7 @@ class ItemProvider(SidebarItemProvider):
     def provide(self):
         return [
             {
-                # category:tools, category:sofware, category:system, category:other
+                # category:tools, category:software, category:system, category:other
                 'attach': 'category:software',
                 'name': 'Docker',
                 'icon': 'fab fa-docker',

--- a/plugins/session_list/README.md
+++ b/plugins/session_list/README.md
@@ -1,3 +1,3 @@
 # Session list plugin
 
-Update the session list of connectd users to show it with details on the frontend.
+Update the session list of connected users to show it with details on the frontend.


### PR DESCRIPTION
There are small typos in:
- ajenti-core/aj/config.py
- docs/source/man/config.rst
- docs/source/man/install.rst
- plugins/cron/views.py
- plugins/docker/main.py
- plugins/session_list/README.md

Fixes:
- Should read `certificate` rather than `certificat`.
- Should read `successful` rather than `successfull`.
- Should read `software` rather than `sofware`.
- Should read `mentioned` rather than `mentionned`.
- Should read `currently` rather than `currenly`.
- Should read `connected` rather than `connectd`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md