### PR TITLE
Fixed wrong Uninstall documentation

### DIFF
--- a/docs/source/man/install.rst
+++ b/docs/source/man/install.rst
@@ -81,10 +81,10 @@ Systemd
 
 ::
 
-    systemd stop ajenti.service
-    systemd disable ajenti.service
-    systemd daemon-reload
-    rm -f /lib/systemd/system/ajenti.service
+    sudo systemctl stop ajenti.service
+    sudo systemctl disable ajenti.service
+    sudo systemctl daemon-reload
+    sudo rm -f /lib/systemd/system/ajenti.service
 
 
 SysVinit


### PR DESCRIPTION
There was an error in this part of the documentation: systemd -> systemctl . I've also added `sudo` before commands that needed root permission, as this syntax was used when installing.