### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/ajenti-core/aj/security/pwreset.py
+++ b/ajenti-core/aj/security/pwreset.py
@@ -130,6 +130,5 @@ class PasswordResetMiddleware(HttpMasterMiddleware):
             if not answer:
                 http_context.respond_forbidden()
                 return [b'403 Forbidden']
-            else:
-                http_context.respond_ok()
-                return [b'200 OK']
+            http_context.respond_ok()
+            return [b'200 OK']

--- a/plugins/core/views/api.py
+++ b/plugins/core/views/api.py
@@ -168,7 +168,7 @@ class Handler(HttpPlugin):
                 'error': None,
             }
 
-        elif mode == 'sudo':
+        if mode == 'sudo':
             target = 'root'
             try:
                 if auth.check_sudo_password(username, password):
@@ -191,7 +191,7 @@ class Handler(HttpPlugin):
                     'error': e.message,
                 }
 
-        elif mode == 'totp':
+        if mode == 'totp':
             # Reset verify value before verifying
             aj.tfa_config.verify_totp[user_auth_id] = None
             self.context.worker.verify_totp(user_auth_id, password)
@@ -202,6 +202,7 @@ class Handler(HttpPlugin):
                     'success': True,
                     'username': username,
                 }
+
         return {
             'success': False,
             'error': 'Invalid mode',

--- a/plugins/dns_api/providers/gandi.py
+++ b/plugins/dns_api/providers/gandi.py
@@ -113,8 +113,7 @@ class GandiApiDnsProvider(ApiDnsManager):
             messages = json.loads(resp.content)
             if messages.get('status', '') == 'error':
                 return resp.status_code, messages['errors']
-            else:
-                return resp.status_code, messages['message']
+            return resp.status_code, messages['message']
         except Exception as e:
             logging.error(e)
 
@@ -141,8 +140,7 @@ class GandiApiDnsProvider(ApiDnsManager):
             messages = json.loads(resp.content)
             if messages.get('status', '') == 'error':
                 return resp.status_code, messages['errors']
-            else:
-                return resp.status_code, messages['message']
+            return resp.status_code, messages['message']
         except Exception as e:
             logging.error(e)
 
@@ -168,7 +166,6 @@ class GandiApiDnsProvider(ApiDnsManager):
                 messages = {'message': 'Entry deleted'}
             if messages.get('status', '') == 'error':
                 return resp.status_code, messages['errors'][0]['description']
-            else:
-                return resp.status_code, messages['message']
+            return resp.status_code, messages['message']
         except Exception as e:
             logging.error(e)

--- a/plugins/filesystem/widget.py
+++ b/plugins/filesystem/widget.py
@@ -24,13 +24,12 @@ class DiskWidget(Widget):
                 'free': sum(x.free for x in usage.values()),
                 'used': sum(x.used for x in usage.values()),
             }
-        elif mountpoint in usage:
+        if mountpoint in usage:
             return {
                 'total': usage[mountpoint].total,
                 'free': usage[mountpoint].free,
                 'used': usage[mountpoint].used,
             }
-
         return {
             'total': None,
             'free': None,


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.