### PR TITLE
Fix: Development setup issues

### DIFF
--- a/.github/workflows/install-ajenti.yml
+++ b/.github/workflows/install-ajenti.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install npm dependencies
       run: |
         sudo npm install -g npm
-        sudo npm install -g bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffee-script
+        sudo npm install -g bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffeescript
         sudo npm install babel-cli babel-preset-es2015 babel-plugin-external-helpers
     - name: Install python dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --build-plugins
 
 bower:
-    python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --bower install
+	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --bower install
 
 run:
 	cd ajenti-panel && ./ajenti-panel -v --autologin --plugins ../plugins-new $(CONFIGFILE)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ build:
 	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --msgfmt
 	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --build-plugins
 
+bower:
+    python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --bower install
+
 run:
 	cd ajenti-panel && ./ajenti-panel -v --autologin --plugins ../plugins-new $(CONFIGFILE)
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ build:
 	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --msgfmt
 	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --build-plugins
 
-bower:
-	python3 ./scripts/ajenti-dev-multitool/ajenti_dev_multitool.py --bower install
-
 run:
 	cd ajenti-panel && ./ajenti-panel -v --autologin --plugins ../plugins-new $(CONFIGFILE)
 

--- a/ajenti-core/aj/config.py
+++ b/ajenti-core/aj/config.py
@@ -34,6 +34,9 @@ class BaseConfig():
         raise NotImplementedError()
 
     def ensure_structure(self):
+        if self.data is None:
+            self.data = {}
+
         # Global options
         self.data.setdefault('name', None)
         self.data.setdefault('trusted_domains', [])
@@ -41,8 +44,15 @@ class BaseConfig():
         self.data.setdefault('max_sessions', 99)
         self.data.setdefault('session_max_time', 3600)
         self.data.setdefault('language', 'en')
+        self.data.setdefault('color', 'blue')
         self.data.setdefault('restricted_user', 'nobody')
         self.data.setdefault('logo', os.path.dirname(__file__) + '/static/images/Logo.png')
+
+        # Bind
+        self.data.setdefault('bind', {})
+        self.data['bind'].setdefault('mode', 'tcp')
+        self.data['bind'].setdefault('host', '0.0.0.0')
+        self.data['bind'].setdefault('port', 8000)
 
         # Main view
         self.data.setdefault('view', {})

--- a/docs/source/dev/intro-core.rst
+++ b/docs/source/dev/intro-core.rst
@@ -21,7 +21,7 @@ Prerequisites
 The following is the absolutely minimal set of software required to build and run Ajenti:
 
   * git
-  * bower, babel, babel-preset-es2015 and lessc (from NPM)
+  * yarn, babel, babel-preset-es2015 and lessc (from NPM)
 
 
 Debian/Ubuntu extras:
@@ -67,12 +67,8 @@ Install the dependencies::
     sudo pip3 install -r ajenti-core/requirements.txt
     sudo pip3 install ajenti-dev-multitool
 
-    sudo npm install -g coffeescript less bower angular-gettext-cli yarn
+    sudo npm install -g coffeescript less angular-gettext-cli yarn
 
-
-Download and install Bower dependencies::
-
-    make bower
 
 Ensure that resource compilation is set up correctly and works (optional)::
 

--- a/docs/source/dev/intro-core.rst
+++ b/docs/source/dev/intro-core.rst
@@ -49,7 +49,7 @@ After a successful installation, do the following to activate the dev mode:
 Manual installation
 ===================
 
-First, it's necessary to complete the install for plugin developpement mentioned here : :ref:`Dev getting started <dev-getting-started>`
+First, it's necessary to complete the install for plugin development mentioned here : :ref:`Dev getting started <dev-getting-started>`
 
 Download the source::
 
@@ -58,7 +58,7 @@ Download the source::
 Install the dependencies::
 
     # Debian/Ubuntu
-    sudo apt-get install build-essential python3-pip python3-dev python3-lxml libffi-dev libssl-dev libjpeg-dev libpng-dev uuid-dev python3-dbus gettext
+    sudo apt-get install build-essential python3-pip python3-dev libffi-dev libssl-dev libjpeg-dev libpng-dev uuid-dev python3-dbus gettext
 
     # RHEL
     sudo dnf install gcc python3-devel python3-pip libxslt-devel libxml2-devel libffi-devel openssl-devel libjpeg-turbo-devel libpng-devel dbus-python gettext
@@ -67,7 +67,7 @@ Install the dependencies::
     sudo pip3 install -r ajenti-core/requirements.txt
     sudo pip3 install ajenti-dev-multitool
 
-    sudo npm install -g coffeescript less bower
+    sudo npm install -g coffeescript less bower angular-gettext-cli yarn
 
 
 Download and install Bower dependencies::
@@ -77,6 +77,13 @@ Download and install Bower dependencies::
 Ensure that resource compilation is set up correctly and works (optional)::
 
     make build
+
+Create config & secret::
+
+    sudo mkdir /etc/ajenti
+    sudo touch /etc/ajenti/config.yml
+    sudo echo "$(tr -dc A-Za-z0-9 </dev/urandom | head -c 50)" > /etc/ajenti/.secret
+
 
 Launch Ajenti in dev mode::
 

--- a/docs/source/dev/intro-core.rst
+++ b/docs/source/dev/intro-core.rst
@@ -67,7 +67,7 @@ Install the dependencies::
     sudo pip3 install -r ajenti-core/requirements.txt
     sudo pip3 install ajenti-dev-multitool
 
-    sudo npm install -g coffee-script less bower
+    sudo npm install -g coffeescript less bower
 
 
 Download and install Bower dependencies::

--- a/docs/source/dev/intro.rst
+++ b/docs/source/dev/intro.rst
@@ -37,7 +37,7 @@ Build tools require NodeJS - you can use the NodeSource repositories for quick s
 
 Now, install the build tools::
 
-    npm -g install bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffeescript angular-gettext-cli angular-gettext-tools
+    npm -g install yarn babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffeescript angular-gettext-cli angular-gettext-tools
 
     # Ubuntu or Debian:
     apt-get install gettext
@@ -106,7 +106,6 @@ Example plugins
 
     Prep work::
 
-        ajenti-dev-multitool --bower install
         ajenti-dev-multitool --rebuild
 
     Run::

--- a/docs/source/dev/intro.rst
+++ b/docs/source/dev/intro.rst
@@ -37,7 +37,7 @@ Build tools require NodeJS - you can use the NodeSource repositories for quick s
 
 Now, install the build tools::
 
-    npm -g install bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffee-script angular-gettext-cli angular-gettext-tools
+    npm -g install bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less coffeescript angular-gettext-cli angular-gettext-tools
 
     # Ubuntu or Debian:
     apt-get install gettext

--- a/e2e/conf.coffee
+++ b/e2e/conf.coffee
@@ -1,4 +1,4 @@
-require 'coffee-script'
+require 'coffeescript'
 
 specs = [
     'specs/notepad.coffee'

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "coffee-script": "~1.8.0",
+    "coffeescript": "~1.8.0",
     "jasmine-spec-reporter": "^1.1.1",
     "protractor": "4.0.10"
   }

--- a/scripts/ajenti-dev-multitool/ajenti_dev_multitool.py
+++ b/scripts/ajenti-dev-multitool/ajenti_dev_multitool.py
@@ -359,7 +359,7 @@ def run_msgfmt(plugin):
     logging.info('Compiling in %s', locale_path)
 
     if subprocess.call(['which', 'msgfmt'], stdout=subprocess.PIPE) != 0:
-        logging.error('msgfmt not found!')
+        logging.error('msgfmt not found! (pkg: gettext)')
         sys.exit(1)
 
     if subprocess.call(['which', 'angular-gettext-cli'], stdout=subprocess.PIPE) != 0:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,7 +13,7 @@ echo -en 'travis_fold:end:deps.python\r'
 
 echo -en 'travis_fold:start:deps.node\r'
     echo Installing NodeJS modules
-    npm install -g bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less npm@3 coffee-script
+    npm install -g bower babel-cli babel-preset-es2015 babel-plugin-external-helpers less npm@3 coffeescript
     npm install babel-cli babel-preset-es2015 babel-plugin-external-helpers
     cd tests-karma
     npm install || exit 1

--- a/tests-karma/package.json
+++ b/tests-karma/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",
     "chai": "~1.10.0",
-    "coffee-script": "~1.8.0",
+    "coffeescript": "~1.8.0",
     "glob": "~4.3.5",
     "istanbul": "~0.3.5",
     "karma": "~0.12.31",


### PR DESCRIPTION
Greetings (:

As mentioned in #1500 I will take a look at the ajenti codebase.

I had some troubles getting the dev-environment up-and-running.

This PR contains some fixes for these issues I've encountered:
* DEV-Docs not up-to-date (commands not working/do not exist)
  * The dev-server will fail if the config-files at `/etc/ajenti` do not exist
  * Renamed `coffee-script` to `coffeescript` as seen in the NPM warnings and NPM-repo: https://www.npmjs.com/package/coffee-script
  * NPM packages `angular-gettext-cli yarn` missing
  * `python3-lxml` should not be necessary as the `ajenti-core/requirements.txt` contains `lxml`
  * Removed `bower` references as it seems to have been deprecated (please correct me if I'm wrong!)
* Ajenti will fail to start and throw 500 errors on some HTTP-calls as not all config-entries have defaults defined. (per example if the `config.yml` is empty)
  This might be a major issue with future development if new settings are defined without defaults. Maybe a check (CI?) would be benefitial?
  If there are settings the user should be required to provide: In that case I personally prefer to validate the config on service-startup and throw clear error-messages.